### PR TITLE
Create endpoint to query entities by classifier path

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -48,7 +48,7 @@
             <property name="message"
                       value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
         </module>
-        <module name="AvoidStarImport"/>
+<!--        <module name="AvoidStarImport"/>-->
         <module name="OneTopLevelClass"/>
         <module name="NoLineWrap"/>
         <module name="EmptyBlock">

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/AdminServicesModule.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/AdminServicesModule.java
@@ -32,13 +32,11 @@ import org.finos.legend.depot.store.mongo.entities.EntitiesMongo;
 import org.finos.legend.depot.store.mongo.generation.file.FileGenerationsMongo;
 import org.finos.legend.depot.store.mongo.projects.ProjectsMongo;
 
-
 public class AdminServicesModule extends PrivateModule
 {
     @Override
     protected void configure()
     {
-
         bind(Projects.class).to(ProjectsMongo.class);
         bind(UpdateProjects.class).to(ProjectsMongo.class);
         bind(Entities.class).to(EntitiesMongo.class);
@@ -50,19 +48,14 @@ public class AdminServicesModule extends PrivateModule
         bind(FileGenerationsService.class).to(FileGenerationsServiceImpl.class);
         bind(ManageFileGenerationsService.class).to(FileGenerationsServiceImpl.class);
 
-
         expose(ManageProjectsService.class);
         expose(ManageEntitiesService.class);
         expose(ManageFileGenerationsService.class);
-
 
         expose(UpdateEntities.class);
         expose(Entities.class);
         expose(UpdateFileGenerations.class);
         expose(Projects.class);
         expose(UpdateProjects.class);
-
     }
-
-
 }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/ReadOnlyServicesModule.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/ReadOnlyServicesModule.java
@@ -18,9 +18,11 @@ package org.finos.legend.depot.services;
 import com.google.inject.PrivateModule;
 import org.finos.legend.depot.services.api.entities.EntitiesService;
 import org.finos.legend.depot.services.api.generation.file.FileGenerationsService;
+import org.finos.legend.depot.services.api.entities.EntityClassifierService;
 import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.depot.services.entities.EntitiesServiceImpl;
 import org.finos.legend.depot.services.generation.file.FileGenerationsServiceImpl;
+import org.finos.legend.depot.services.entities.EntityClassifierServiceImpl;
 import org.finos.legend.depot.services.projects.ProjectsServiceImpl;
 import org.finos.legend.depot.store.api.entities.Entities;
 import org.finos.legend.depot.store.api.entities.UpdateEntities;
@@ -37,7 +39,6 @@ public class ReadOnlyServicesModule extends PrivateModule
     @Override
     protected void configure()
     {
-
         bind(Projects.class).to(ProjectsMongo.class);
         bind(Entities.class).to(EntitiesMongo.class);
         bind(UpdateEntities.class).to(EntitiesMongo.class);
@@ -46,13 +47,13 @@ public class ReadOnlyServicesModule extends PrivateModule
         bind(UpdateFileGenerations.class).to(FileGenerationsMongo.class);
 
         bind(EntitiesService.class).to(EntitiesServiceImpl.class);
+        bind(EntityClassifierService.class).to(EntityClassifierServiceImpl.class);
         bind(ProjectsService.class).to(ProjectsServiceImpl.class);
         bind(FileGenerationsService.class).to(FileGenerationsServiceImpl.class);
 
         expose(ProjectsService.class);
         expose(EntitiesService.class);
+        expose(EntityClassifierService.class);
         expose(FileGenerationsService.class);
-
     }
-
 }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/entities/EntitiesService.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/entities/EntitiesService.java
@@ -66,5 +66,4 @@ public interface EntitiesService
     List<StoredEntity> findLatestEntitiesByClassifier(String classifier, boolean summary, boolean versioned);
 
     List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, boolean summary, boolean versioned);
-
 }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/entities/EntityClassifierService.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/entities/EntityClassifierService.java
@@ -1,0 +1,25 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.services.api.entities;
+
+import org.finos.legend.depot.domain.entity.StoredEntity;
+
+import java.util.List;
+
+public interface EntityClassifierService
+{
+    List<StoredEntity> getEntitiesByClassifierPath(String classifierPath, String search, Integer limit);
+}

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/entities/EntityClassifierServiceImpl.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/entities/EntityClassifierServiceImpl.java
@@ -1,0 +1,90 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.services.entities;
+
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.depot.domain.entity.StoredEntity;
+import org.finos.legend.depot.domain.project.ProjectData;
+import org.finos.legend.depot.services.api.entities.EntitiesService;
+import org.finos.legend.depot.services.api.entities.EntityClassifierService;
+import org.finos.legend.depot.services.api.projects.ProjectsService;
+import org.finos.legend.sdlc.domain.model.version.VersionId;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class EntityClassifierServiceImpl implements EntityClassifierService
+{
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(EntityClassifierServiceImpl.class);
+    private final EntitiesService entities;
+    private final ProjectsService projects;
+
+    @Inject
+    public EntityClassifierServiceImpl(ProjectsService projects, EntitiesService versions)
+    {
+        this.projects = projects;
+        this.entities = versions;
+    }
+
+    private Set<StoredEntity> findReleasedEntitiesByClassifier(String classifierPath)
+    {
+        Stream<StoredEntity> allEntities = this.entities.findReleasedEntitiesByClassifier(classifierPath, false, false).stream();
+        LOGGER.info("finished getting entities by classifier path {} ", classifierPath);
+        Map<String, Optional<VersionId>> latestVersions = projects.getAll().stream().collect(Collectors.toMap(k -> k.getGroupId() + ":" + k.getArtifactId(), ProjectData::getLatestVersion));
+        LOGGER.info("getting entities by latest version classifier path {} ", classifierPath);
+        allEntities = allEntities.filter(ent ->
+        {
+            Optional<VersionId> version = latestVersions.get(ent.getGroupId() + ":" + ent.getArtifactId());
+            return version.isPresent() && version.get().toVersionIdString().equals(ent.getVersionId());
+        });
+        Set<StoredEntity> uniqueEntities = allEntities.collect(Collectors.toSet());
+        LOGGER.info("found {} ", uniqueEntities.size());
+        Map<Pair<String, String>, Integer> counts = new HashMap<>();
+
+        uniqueEntities.forEach(ent ->
+        {
+            int count = counts.getOrDefault(Tuples.pair(ent.getGroupId() + ":" + ent.getArtifactId(), ent.getVersionId()), 0) + 1;
+            counts.put(Tuples.pair(ent.getGroupId() + ":" + ent.getArtifactId(), ent.getVersionId()), count);
+        });
+
+        return uniqueEntities;
+    }
+
+    @Override
+    public List<StoredEntity> getEntitiesByClassifierPath(String classifierPath, String search, Integer limit)
+    {
+        List<StoredEntity> entities = new ArrayList<>(this.findReleasedEntitiesByClassifier(classifierPath));
+        if (search != null)
+        {
+            entities = ListIterate.select(entities, entity -> entity.getEntity().getPath().contains(search));
+        }
+        if (limit != null)
+        {
+            entities = ListIterate.take(entities, limit);
+        }
+        return entities;
+    }
+}

--- a/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/tracing/resources/ResourceLoggingAndTracing.java
+++ b/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/tracing/resources/ResourceLoggingAndTracing.java
@@ -67,7 +67,7 @@ public class ResourceLoggingAndTracing
     public static final String TOGGLE_SCHEDULE = "toggle schedule";
     public static final String ENQUEUE_REFRESH_ALL_EVENT = "queue refresh all";
     public static final String ORPHAN_STORE_ENTITIES = "get orphaned entities";
-
+    public static final String GET_ENTITIES_BY_CLASSIFIER_PATH = "get entities by classifier path";
 
     private ResourceLoggingAndTracing()
     {

--- a/legend-depot-server/Dockerfile
+++ b/legend-depot-server/Dockerfile
@@ -1,2 +1,22 @@
-FROM alpine
-CMD ["echo", "Hello StackOverflow!"]
+# Copyright 2021 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openjdk:11.0.12
+COPY target/legend-depot-server-*.jar /app/bin/
+CMD java -cp /app/bin/*-shaded.jar \
+-XX:+ExitOnOutOfMemoryError \
+-XX:MaxRAMPercentage=60 \
+-Xss4M \
+-Dfile.encoding=UTF8 \
+org.finos.legend.depot.server.LegendDepotServer server /config/config.json

--- a/legend-depot-server/pom.xml
+++ b/legend-depot-server/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>guava</artifactId>
         </dependency>
 
-        <!--Testing-->
+        <!-- TEST -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -91,6 +91,7 @@
             <artifactId>mongo-java-server</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- TEST -->
     </dependencies>
 
     <build>

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/guice/DepotServerResourcesModule.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/guice/DepotServerResourcesModule.java
@@ -20,6 +20,7 @@ import org.finos.legend.depot.server.resources.ProjectsResource;
 import org.finos.legend.depot.server.resources.dependencies.DependenciesResource;
 import org.finos.legend.depot.server.resources.entities.EntitiesResource;
 import org.finos.legend.depot.server.resources.file.FileGenerationsResource;
+import org.finos.legend.depot.server.resources.entities.EntityClassifierResource;
 
 public class DepotServerResourcesModule extends PrivateModule
 {
@@ -28,13 +29,14 @@ public class DepotServerResourcesModule extends PrivateModule
     {
         bind(ProjectsResource.class);
         bind(EntitiesResource.class);
+        bind(EntityClassifierResource.class);
         bind(DependenciesResource.class);
         bind(FileGenerationsResource.class);
 
         expose(ProjectsResource.class);
+        expose(EntityClassifierResource.class);
         expose(EntitiesResource.class);
         expose(DependenciesResource.class);
         expose(FileGenerationsResource.class);
     }
-
 }

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/dependencies/DependenciesResource.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/dependencies/DependenciesResource.java
@@ -40,16 +40,12 @@ import java.util.List;
 import java.util.Set;
 
 import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_DEPENDANT_PROJECTS;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_PROJECT_DEPENDENCIES;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_REVISION_DEPENDENCY_ENTITIES;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_DEPENDENCY_ENTITIES;
+import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.*;
 
 @Path("")
 @Api("Dependencies")
 public class DependenciesResource extends BaseResource
 {
-
     private final EntitiesService entitiesService;
     private final ProjectsService projectApi;
 
@@ -103,7 +99,6 @@ public class DependenciesResource extends BaseResource
         return handle(GET_VERSION_DEPENDENCY_ENTITIES, () -> this.entitiesService.getDependenciesEntities(groupId, artifactId, versionId, versioned, transitive, includeOrigin));
     }
 
-
     @GET
     @Path("/projects/{groupId}/{artifactId}/revisions/latest/dependants")
     @ApiOperation(GET_REVISION_DEPENDENCY_ENTITIES)
@@ -122,7 +117,6 @@ public class DependenciesResource extends BaseResource
         return handle(GET_REVISION_DEPENDENCY_ENTITIES, () -> this.entitiesService.getLatestDependenciesEntities(groupId, artifactId, versioned, transitive, includeOrigin));
     }
 
-
     @POST
     @Path("/projects/dependencies")
     @ApiOperation(GET_VERSION_DEPENDENCY_ENTITIES)
@@ -136,9 +130,7 @@ public class DependenciesResource extends BaseResource
                                                                        @ApiParam("Whether to return start of dependency tree") boolean includeOrigin)
     {
         projectDependencies.forEach(dep ->
-                QueryMetricsContainer.record(dep.getGroupId(), dep.getArtifactId(), dep.getVersionId()));
+            QueryMetricsContainer.record(dep.getGroupId(), dep.getArtifactId(), dep.getVersionId()));
         return handle(GET_VERSION_DEPENDENCY_ENTITIES, () -> this.entitiesService.getDependenciesEntities(projectDependencies, versioned, transitive, includeOrigin));
     }
-
-
 }

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/entities/EntitiesResource.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/entities/EntitiesResource.java
@@ -36,18 +36,12 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_REVISION_ENTITIES;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_REVISION_ENTITIES_BY_PACKAGE;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_REVISION_ENTITY;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_ENTITIES;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_ENTITIES_BY_PACKAGE;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_ENTITY;
+import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.*;
 
 @Path("")
 @Api("Entities")
 public class EntitiesResource extends BaseResource
 {
-
     private final EntitiesService entitiesService;
 
     @Inject
@@ -152,6 +146,4 @@ public class EntitiesResource extends BaseResource
         QueryMetricsContainer.record(groupId, artifactId, MASTER_SNAPSHOT);
         return handle(GET_REVISION_ENTITIES_BY_PACKAGE, GET_REVISION_ENTITIES_BY_PACKAGE + packageName, () -> this.entitiesService.getLatestEntitiesByPackage(groupId, artifactId, packageName, versioned, classifierPaths, includeSubPackages));
     }
-
-
 }

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/entities/EntityClassifierResource.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/entities/EntityClassifierResource.java
@@ -1,0 +1,61 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.server.resources.entities;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.finos.legend.depot.domain.entity.StoredEntity;
+import org.finos.legend.depot.services.api.entities.EntityClassifierService;
+import org.finos.legend.depot.tracing.resources.BaseResource;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_ENTITIES_BY_CLASSIFIER_PATH;
+
+@Path("")
+@Api("Entities")
+public class EntityClassifierResource extends BaseResource
+{
+    private final EntityClassifierService graphService;
+
+    @Inject
+    public EntityClassifierResource(EntityClassifierService graphService)
+    {
+        this.graphService = graphService;
+    }
+
+    @GET
+    @Path("/entitiesByClassifierPath/{classifierPath}")
+    // This API is built temporarily to address needs to query entities by classifier path
+    // The bigger plan is to allow a generic execution endpoint to fire arbitrary query against the metadata
+    // graph built in depot server.
+    @ApiOperation(value = GET_ENTITIES_BY_CLASSIFIER_PATH, hidden = true)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<StoredEntity> getEntities(@PathParam("classifierPath") @ApiParam("The classifier path of the entities") String classifierPath,
+                                          @QueryParam("search") @ApiParam("The search string that the entity path contains") String search,
+                                          @QueryParam("limit") @ApiParam("Limit the number of entities returned") Integer limit)
+    {
+        return handle(GET_ENTITIES_BY_CLASSIFIER_PATH, () -> this.graphService.getEntitiesByClassifierPath(classifierPath, search, limit));
+    }
+}

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/file/FileGenerationsResource.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/file/FileGenerationsResource.java
@@ -29,19 +29,11 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Optional;
 
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_REVISION_FILE_GENERATION;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_REVISION_FILE_GENERATION_BY_FILEPATH;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_REVISION_FILE_GENERATION_BY_PATH;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_REVISION_FILE_GENERATION_ENTITIES;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_FILE_GENERATION;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_FILE_GENERATION_BY_FILEPATH;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_FILE_GENERATION_BY_PATH;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_FILE_GENERATION_ENTITIES;
+import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.*;
 
 @Path("")
 @Api("File Generations")
@@ -149,5 +141,4 @@ public class FileGenerationsResource extends BaseResource
         QueryMetricsContainer.record(groupId, artifactId, versionId);
         return handle(GET_VERSION_FILE_GENERATION_BY_FILEPATH, () -> this.generationsService.getFileGenerationsByFile(groupId, artifactId, versionId, file));
     }
-
 }

--- a/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/api/entities/Entities.java
+++ b/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/api/entities/Entities.java
@@ -26,14 +26,12 @@ import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAP
 
 public interface Entities
 {
-
     List<Entity> getAllEntities(String groupId, String artifactId, String versionId);
 
     default List<Entity> getAllLatestEntities(String groupId, String artifactId)
     {
         return getAllEntities(groupId, artifactId, MASTER_SNAPSHOT);
     }
-
 
     List<Entity> getEntities(String groupId, String artifactId, String versionId, boolean versionedEntities);
 
@@ -76,6 +74,4 @@ public interface Entities
     List<StoredEntity> findLatestEntitiesByClassifier(String classifier, boolean summary, boolean versioned);
 
     List<StoredEntity> findEntitiesByClassifier(String groupId, String artifactId, String versionId, String classifier, boolean summary, boolean versionedEntities);
-
-
 }

--- a/legend-depot-store-server/Dockerfile
+++ b/legend-depot-store-server/Dockerfile
@@ -1,2 +1,22 @@
-FROM alpine
-CMD ["echo", "Hello StackOverflow!"]
+# Copyright 2021 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openjdk:11.0.12
+COPY target/legend-depot-store-server-*.jar /app/bin/
+CMD java -cp /app/bin/*-shaded.jar \
+-XX:+ExitOnOutOfMemoryError \
+-XX:MaxRAMPercentage=60 \
+-Xss4M \
+-Dfile.encoding=UTF8 \
+org.finos.legend.depot.store.server.LegendDepotStoreServer server /config/config.json


### PR DESCRIPTION
Closes https://github.com/finos/legend-depot/issues/20

### Done
We created an API **(labelled as WIP)** which
- [x] `POST` endpoint which takes a `Lambda` (engine protocol)
- [x] return a JSON object
- [x] Only accept lambda of form `SomeClassifierPath.all()`, everything else would throw `Bad Request`. So the JSON sample input is:

```json
{
  "_type": "lambda",
  "body": [
    {
      "_type": "func",
      "function": "getAll",
      "parameters": [
        {
          "_type": "packageableElementPtr",
          "fullPath": "meta::pure::metamodel::type::Class"
        }
      ]
    }
  ],
  "parameters": []
}
```

### Limitation

At first we thought we could be fancy and support lambda of form `DataSpace.all()->filter(s|$s.path->contains(<string>))->take(<limit>)` and the search will only limit to latest release of all the projects. But this is not possible with the current way entities are stored in `depot` as entities of **all** versions are stored. As such, either we invest more time (and space) to create another Mongo collection to store entities from the latest versions or alter the model of `StoredEntity` or simplify to let `Studio` handle the filtering complexity. If we follow the latter, we would not be able to provide the `typeahead-like` experience in `depot` with limit and search the entity paths by search text