### PR TITLE
Included shaded jar as a separate artifact

### DIFF
--- a/legend-depot-server/pom.xml
+++ b/legend-depot-server/pom.xml
@@ -145,6 +145,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/legend-depot-store-server/pom.xml
+++ b/legend-depot-store-server/pom.xml
@@ -135,6 +135,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
This PR modifies the shading to include the shaded jar as a separate artifact. 

Without shadedArtifactAttached=true, the main jar becomes the shaded jar. However the Dockerfiles use a wildcard that refers to  ```*shaded.jar```.

This fixes the Dockerfile's CLASSPATH and also makes the shading configuration (more) consistent with the other Legend projects.