### PR TITLE
Add pac4j gitlab dependency

### DIFF
--- a/legend-depot-server/pom.xml
+++ b/legend-depot-server/pom.xml
@@ -64,6 +64,20 @@
         </dependency>
         <!-- DEPOT -->
 
+        <!-- SHARED -->
+        <dependency>
+            <groupId>org.finos.legend.shared</groupId>
+            <artifactId>legend-shared-pac4j-gitlab</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- SHARED -->
+
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>


### PR DESCRIPTION
The depot-server module is missing the runtime dependency. 