### PR TITLE
Enable variable substitution with environment variables

### DIFF
--- a/legend-depot-core-http/pom.xml
+++ b/legend-depot-core-http/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>dropwizard-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-configuration</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
         </dependency>

--- a/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/BaseServer.java
+++ b/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/BaseServer.java
@@ -39,6 +39,8 @@ import org.finos.legend.server.shared.bundles.ChainFixingFilterHandler;
 import org.finos.legend.server.shared.bundles.HostnameHeaderBundle;
 import org.finos.legend.server.shared.bundles.OpenTracingBundle;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
@@ -70,6 +72,9 @@ public abstract class BaseServer<T extends ServersConfiguration> extends Applica
                 return configuration.getSwaggerBundleConfiguration();
             }
         });
+
+        // Enable variable substitution with environment variables
+        bootstrap.setConfigurationSourceProvider(new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(true)));
 
         bootstrap.getObjectMapper().setDateFormat(new SimpleDateFormat(SIMPLE_DATE_FORMAT));
 

--- a/pom.xml
+++ b/pom.xml
@@ -837,6 +837,11 @@
                 <version>${dropwizard.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-configuration</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.smoketurner</groupId>
                 <artifactId>dropwizard-swagger</artifactId>
                 <version>${dropwizard-swagger.version}</version>


### PR DESCRIPTION
This PR allows the server's configuration file to refer to environment variables. This allows for dynamic configuration such as Gitlab configuration values to be injected at runtime (via the environment).