### PR TITLE
Updating image scan workflow trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,12 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "**/Dockerfile"
   pull_request:
-    branches:
-      - "**"
+    paths:
+      - "**/Dockerfile"
+  workflow_dispatch: {}
 
 jobs:
   release:

--- a/legend-depot-server/Dockerfile
+++ b/legend-depot-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:11.0.15-bullseye
+FROM openjdk:11.0.16-bullseye
 COPY target/legend-depot-server-*.jar /app/bin/
 CMD java -cp /app/bin/*-shaded.jar \
 -XX:+ExitOnOutOfMemoryError \

--- a/legend-depot-store-server/Dockerfile
+++ b/legend-depot-store-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:11.0.15-bullseye
+FROM openjdk:11.0.16-bullseye
 COPY target/legend-depot-store-server-*.jar /app/bin/
 CMD java -cp /app/bin/*-shaded.jar \
 -XX:+ExitOnOutOfMemoryError \


### PR DESCRIPTION
This PR disables the docker workflow from being globally run for all PRs.
Instead the action is run only if the PR changes the Dockerfile.

We are doing this because many of the CVEs do not have simple fixes and all the PRs are reported as failing a PR check.