### PR TITLE
allow specifying session cookie name

### DIFF
--- a/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/BaseServer.java
+++ b/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/BaseServer.java
@@ -92,7 +92,12 @@ public abstract class BaseServer<T extends ServersConfiguration> extends Applica
     @Override
     public void run(T configuration, Environment environment)
     {
-        environment.servlets().setSessionHandler(new SessionHandler());
+        SessionHandler sessionHandler = new SessionHandler();
+        if (configuration.getSessionCookie() != null)
+        {
+            sessionHandler.setSessionCookie(configuration.getSessionCookie());
+        }
+        environment.servlets().setSessionHandler(sessionHandler);
 
         if (configuration.getFilterPriorities() != null)
         {

--- a/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/ServersConfiguration.java
+++ b/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/ServersConfiguration.java
@@ -30,6 +30,12 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServersConfiguration extends Configuration
 {
+
+    // This can be set to avoid Jetty session cookie name collision between multiple servers running on `localhost` during development
+    // See https://stackoverflow.com/questions/16789495/two-applications-on-the-same-server-use-the-same-jsessionid
+    @JsonProperty("sessionCookie")
+    private String sessionCookie;
+
     @NotNull
     @JsonProperty("applicationName")
     private String applicationName;
@@ -80,6 +86,11 @@ public class ServersConfiguration extends Configuration
     public void setOpenTracingConfiguration(OpenTracingConfiguration openTracingConfiguration)
     {
         this.openTracingConfiguration = openTracingConfiguration;
+    }
+
+    public String getSessionCookie()
+    {
+        return sessionCookie;
     }
 
     public String getApplicationName()

--- a/legend-depot-server/src/test/resources/sample-server-config.json
+++ b/legend-depot-server/src/test/resources/sample-server-config.json
@@ -1,6 +1,7 @@
 {
   "applicationName": "Legend Depot API",
   "deployment": "DEV",
+  "sessionCookie": "LEGEND_DEPOT_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",

--- a/legend-depot-store-server/src/test/resources/sample-server-config.json
+++ b/legend-depot-store-server/src/test/resources/sample-server-config.json
@@ -1,6 +1,7 @@
 {
   "applicationName": "Depot Store Manager API",
   "deployment": "DEV",
+  "sessionCookie": "LEGEND_DEPOT_STORE_JSESSIONID",
   "server": {
     "type": "simple",
     "applicationContextPath": "/",


### PR DESCRIPTION
Allow specifying session cookie name to help with local development (when we have multiple Legend applications)

see https://stackoverflow.com/questions/16789495/two-applications-on-the-same-server-use-the-same-jsessionid