### PR TITLE
improve performance for entitiesByClassifier API

### DIFF
--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/entities/EntitiesService.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/entities/EntitiesService.java
@@ -18,6 +18,7 @@ package org.finos.legend.depot.services.api.entities;
 import org.finos.legend.depot.domain.entity.ProjectVersionEntities;
 import org.finos.legend.depot.domain.entity.StoredEntity;
 import org.finos.legend.depot.domain.project.ProjectVersion;
+import org.finos.legend.depot.domain.version.Scope;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 
 import java.util.Arrays;
@@ -63,7 +64,7 @@ public interface EntitiesService
         return getDependenciesEntities(groupId, artifactId, MASTER_SNAPSHOT, versioned, transitive, includeOrigin);
     }
 
-    List<StoredEntity> findLatestEntitiesByClassifier(String classifier, boolean summary, boolean versioned);
+    List<StoredEntity> findLatestEntitiesByClassifier(String classifier, String search, Integer limit, boolean summary, boolean versioned);
 
-    List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, boolean summary, boolean versioned);
+    List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, String search, List<ProjectVersion> projectVersions, Integer limit, boolean summary, boolean versioned);
 }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/entities/EntityClassifierService.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/entities/EntityClassifierService.java
@@ -18,9 +18,9 @@ package org.finos.legend.depot.services.api.entities;
 import org.finos.legend.depot.domain.entity.StoredEntity;
 import org.finos.legend.depot.domain.version.Scope;
 
-import java.util.Set;
+import java.util.List;
 
 public interface EntityClassifierService
 {
-    Set<StoredEntity> getEntitiesByClassifierPath(String classifierPath, String search, Scope scope, Integer limit);
+    List<StoredEntity> getEntitiesByClassifierPath(String classifierPath, String search, Scope scope, Integer limit);
 }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
@@ -28,8 +28,12 @@ import java.util.Set;
 
 public interface ProjectsService
 {
-
     List<ProjectData> getAll();
+
+    /**
+     * NOTE: page starting from 1
+     */
+    List<ProjectData> getProjects(int page, int pageSize);
 
     List<ProjectData> findByProjectId(String projectId);
 

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
@@ -96,15 +96,15 @@ public class EntitiesServiceImpl implements ManageEntitiesService, EntitiesServi
     }
 
     @Override
-    public List<StoredEntity> findLatestEntitiesByClassifier(String classifier, boolean summary, boolean versioned)
+    public List<StoredEntity> findLatestEntitiesByClassifier(String classifier, String search, Integer limit, boolean summary, boolean versioned)
     {
-        return entities.findLatestEntitiesByClassifier(classifier, summary, versioned);
+        return entities.findLatestEntitiesByClassifier(classifier, search, limit, summary, versioned);
     }
 
     @Override
-    public List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, boolean summary, boolean versioned)
+    public List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, String search, List<ProjectVersion> projectVersions, Integer limit, boolean summary, boolean versioned)
     {
-        return entities.findReleasedEntitiesByClassifier(classifier, summary, versioned);
+        return entities.findReleasedEntitiesByClassifier(classifier, search, projectVersions, limit, summary, versioned);
     }
 
     @Override

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/entities/EntityClassifierServiceImpl.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/entities/EntityClassifierServiceImpl.java
@@ -15,8 +15,9 @@
 
 package org.finos.legend.depot.services.entities;
 
+import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.depot.domain.entity.StoredEntity;
-import org.finos.legend.depot.domain.project.ProjectData;
+import org.finos.legend.depot.domain.project.ProjectVersion;
 import org.finos.legend.depot.domain.version.Scope;
 import org.finos.legend.depot.services.api.entities.EntitiesService;
 import org.finos.legend.depot.services.api.entities.EntityClassifierService;
@@ -25,11 +26,9 @@ import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class EntityClassifierServiceImpl implements EntityClassifierService
 {
@@ -44,40 +43,41 @@ public class EntityClassifierServiceImpl implements EntityClassifierService
         this.entities = versions;
     }
 
-    @Override
-    public Set<StoredEntity> getEntitiesByClassifierPath(String classifierPath, String search, Scope scope, Integer limit)
+    private List<ProjectVersion> getProjectsInfo(int page, int pageSize)
     {
-        Stream<StoredEntity> entities;
+        return ListIterate.collect(projects.getProjects(page, pageSize), projectData ->
+        {
+            VersionId latestVersion = projectData.getLatestVersion().orElse(null);
+            return new ProjectVersion(projectData.getGroupId(), projectData.getArtifactId(), latestVersion != null ? latestVersion.toVersionIdString() : null);
+        }).select(info -> info.getVersionId() != null);
+    }
+
+    @Override
+    public List<StoredEntity> getEntitiesByClassifierPath(String classifierPath, String search, Scope scope, Integer limit)
+    {
         if (Scope.SNAPSHOT.equals(scope))
         {
-            entities = this.entities.findLatestEntitiesByClassifier(classifierPath, false, false).stream();
+            return this.entities.findLatestEntitiesByClassifier(classifierPath, search, limit, false, false);
         }
-        else
+        List<StoredEntity> result = new ArrayList<>();
+        int PAGE_SIZE = 100;
+        int currentPage = 1;
+        List<ProjectVersion> projectVersions = this.getProjectsInfo(currentPage, PAGE_SIZE);
+        while (!projectVersions.isEmpty())
         {
-            entities = this.entities.findReleasedEntitiesByClassifier(classifierPath, false, false).stream();
-            Map<String, Optional<VersionId>> latestVersions = projects.getAll().stream().collect(Collectors.toMap(k -> k.getGroupId() + ":" + k.getArtifactId(), ProjectData::getLatestVersion));
-
-            LOGGER.info("getting entities by latest version classifier path {} ", classifierPath);
-            entities = entities.filter(ent ->
+            List<StoredEntity> entities = this.entities.findReleasedEntitiesByClassifier(classifierPath, search, projectVersions, limit, false, false);
+            result.addAll(entities);
+            if (limit != null && result.size() >= limit)
             {
-                Optional<VersionId> version = latestVersions.get(ent.getGroupId() + ":" + ent.getArtifactId());
-                return version.isPresent() && version.get().toVersionIdString().equals(ent.getVersionId());
-            });
+                break;
+            }
+            currentPage++;
+            projectVersions = this.getProjectsInfo(currentPage, PAGE_SIZE);
         }
-        entities = entities.distinct();
-        LOGGER.info("finished getting entities by classifier path {} ", classifierPath);
-
-        if (search != null)
-        {
-            LOGGER.info("getting entities by search string {} ", search);
-            entities = entities.filter(entity -> entity.getEntity().getPath().contains(search));
-        }
-
         if (limit != null)
         {
-            entities = entities.limit(limit);
+            result = result.stream().limit(limit).collect(Collectors.toList());
         }
-
-        return entities.collect(Collectors.toSet());
+        return result;
     }
 }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
@@ -63,6 +63,12 @@ public class ProjectsServiceImpl implements ManageProjectsService
     }
 
     @Override
+    public List<ProjectData> getProjects(int page, int pageSize)
+    {
+        return projects.getProjects(page, pageSize);
+    }
+
+    @Override
     public List<ProjectData> findByProjectId(String id)
     {
         return projects.findByProjectId(id);

--- a/legend-depot-model/src/main/java/org/finos/legend/depot/domain/project/ProjectVersion.java
+++ b/legend-depot-model/src/main/java/org/finos/legend/depot/domain/project/ProjectVersion.java
@@ -40,7 +40,6 @@ public class ProjectVersion extends BaseDomain
         return versionId;
     }
 
-
     @Override
     public boolean equals(Object obj)
     {

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/entities/EntityClassifierResource.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/entities/EntityClassifierResource.java
@@ -31,7 +31,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import java.util.Set;
+import java.util.List;
 
 import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_ENTITIES_BY_CLASSIFIER_PATH;
 
@@ -54,10 +54,10 @@ public class EntityClassifierResource extends BaseResource
     // graph built in depot server.
     @ApiOperation(value = GET_ENTITIES_BY_CLASSIFIER_PATH, hidden = true)
     @Produces(MediaType.APPLICATION_JSON)
-    public Set<StoredEntity> getEntities(@PathParam("classifierPath") @ApiParam("The classifier path of the entities") String classifierPath,
-                                         @QueryParam("search") @ApiParam("The search string that the entity path contains") String search,
-                                         @QueryParam("scope") @ApiParam("Whether to return entities for the latest released version or snapshot") @DefaultValue("RELEASES") Scope scope,
-                                         @QueryParam("limit") @ApiParam("Limit the number of entities returned") Integer limit)
+    public List<StoredEntity> getEntities(@PathParam("classifierPath") @ApiParam("The classifier path of the entities") String classifierPath,
+                                          @QueryParam("search") @ApiParam("The search string that the entity path contains") String search,
+                                          @QueryParam("scope") @ApiParam("Whether to return entities for the latest released version or snapshot") @DefaultValue("RELEASES") Scope scope,
+                                          @QueryParam("limit") @ApiParam("Limit the number of entities returned") Integer limit)
     {
         return handle(GET_ENTITIES_BY_CLASSIFIER_PATH, () -> this.graphService.getEntitiesByClassifierPath(classifierPath, search, scope, limit));
     }

--- a/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/api/entities/Entities.java
+++ b/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/api/entities/Entities.java
@@ -16,6 +16,7 @@
 package org.finos.legend.depot.store.api.entities;
 
 import org.finos.legend.depot.domain.entity.StoredEntity;
+import org.finos.legend.depot.domain.project.ProjectVersion;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 
 import java.util.List;
@@ -69,9 +70,9 @@ public interface Entities
 
     List<StoredEntity> getAllStoredEntities();
 
-    List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, boolean summary, boolean versionedEntities);
+    List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, String search, List<ProjectVersion> projectVersions, Integer limit, boolean summary, boolean versionedEntities);
 
-    List<StoredEntity> findLatestEntitiesByClassifier(String classifier, boolean summary, boolean versioned);
+    List<StoredEntity> findLatestEntitiesByClassifier(String classifier, String search, Integer limit, boolean summary, boolean versioned);
 
     List<StoredEntity> findEntitiesByClassifier(String groupId, String artifactId, String versionId, String classifier, boolean summary, boolean versionedEntities);
 }

--- a/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/api/projects/Projects.java
+++ b/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/api/projects/Projects.java
@@ -31,6 +31,11 @@ public interface Projects
 
     List<ProjectData> getAll();
 
+    /**
+     * NOTE: page starting from 1
+     */
+    List<ProjectData> getProjects(int page, int pageSize);
+
     List<ProjectData> findByProjectId(String projectId);
 
     Optional<ProjectData> find(String groupId, String artifactId);

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/BaseMongo.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/BaseMongo.java
@@ -147,6 +147,13 @@ public abstract class BaseMongo<T extends HasIdentifier>
         return result;
     }
 
+    public List<T> getStoredEntitiesByPage(int page, int pageSize)
+    {
+        List<T> result = new ArrayList<>();
+        getCollection().find().skip(Math.max(page - 1, 0) * pageSize).limit(pageSize).forEach((Consumer<Document>)doc -> result.add(convert(doc, documentClass)));
+        return result;
+    }
+
     public <T> T convert(Document document, Class<T> clazz)
     {
         if (document == null)

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/entities/EntitiesMongo.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/entities/EntitiesMongo.java
@@ -27,6 +27,7 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
@@ -34,9 +35,11 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
+import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.depot.domain.EntityValidator;
 import org.finos.legend.depot.domain.entity.StoredEntity;
 import org.finos.legend.depot.domain.entity.StoredEntityOverview;
+import org.finos.legend.depot.domain.project.ProjectVersion;
 import org.finos.legend.depot.domain.status.StoreOperationResult;
 import org.finos.legend.depot.domain.version.VersionValidator;
 import org.finos.legend.depot.store.api.entities.Entities;
@@ -56,11 +59,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.mongodb.client.model.Aggregates.group;
 import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.ne;
 import static com.mongodb.client.model.Filters.regex;
@@ -81,6 +86,7 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
     public static final String PATH = "path";
     public static final String ENTITY_PACKAGE = "entity.content.package";
     public static final String VERSIONED_ENTITY = "versionedEntity";
+    private static final int MAX_NUMBER_ENTITIES = 100;
 
 
     public final boolean transactionMode;
@@ -338,7 +344,6 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
         return entities.collect(Collectors.toList());
     }
 
-
     protected List<StoredEntity> transform(boolean summary, FindIterable query)
     {
         if (!summary)
@@ -346,30 +351,48 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
             return convert(query);
         }
         List<StoredEntity> result = new ArrayList<>();
-        query.forEach((Consumer<Document>)doc ->
+        query.forEach((Consumer<Document>) doc ->
         {
-            Map<String, Object> entity = (Map<String, Object>)doc.get(ENTITY);
-            result.add(new StoredEntityOverview(doc.getString(GROUP_ID), doc.getString(ARTIFACT_ID), doc.getString(VERSION_ID), doc.getBoolean(VERSIONED_ENTITY),(String)entity.get(PATH), (String)entity.get(CLASSIFIER_PATH)));
+            Map<String, Object> entity = (Map<String, Object>) doc.get(ENTITY);
+            result.add(new StoredEntityOverview(doc.getString(GROUP_ID), doc.getString(ARTIFACT_ID), doc.getString(VERSION_ID), doc.getBoolean(VERSIONED_ENTITY), (String) entity.get(PATH), (String) entity.get(CLASSIFIER_PATH)));
         });
         return result;
     }
 
     @Override
-    public List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, boolean summary, boolean versionedEntities)
+    public List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, String search, List<ProjectVersion> projectVersions, Integer limit, boolean summary, boolean versioned)
     {
-        return transform(summary, executeFind(and(and(eq(ENTITY_CLASSIFIER_PATH, classifier), eq(VERSIONED_ENTITY, versionedEntities)), ne(VERSION_ID, MASTER_SNAPSHOT))));
+        List<Bson> filters = new ArrayList<>();
+        filters.add(eq(ENTITY_CLASSIFIER_PATH, classifier));
+        filters.add(eq(VERSIONED_ENTITY, versioned));
+        if (projectVersions != null && !projectVersions.isEmpty())
+        {
+            filters.add(or(ListIterate.collect(projectVersions, projectVersion -> getArtifactAndVersionFilter(projectVersion.getGroupId(), projectVersion.getArtifactId(), projectVersion.getVersionId()))));
+        }
+        if (search != null)
+        {
+            filters.add(Filters.regex(ENTITY_PATH, Pattern.quote(search), "i"));
+        }
+        return transform(summary, executeFind(and(filters)).limit(Math.min(MAX_NUMBER_ENTITIES, limit == null ? Integer.MAX_VALUE : limit)));
     }
 
+    @Override
+    public List<StoredEntity> findLatestEntitiesByClassifier(String classifier, String search, Integer limit, boolean summary, boolean versioned)
+    {
+        List<Bson> filters = new ArrayList<>();
+        filters.add(eq(ENTITY_CLASSIFIER_PATH, classifier));
+        filters.add(eq(VERSIONED_ENTITY, versioned));
+        filters.add(eq(VERSION_ID, MASTER_SNAPSHOT));
+        if (search != null)
+        {
+            filters.add(Filters.regex(ENTITY_PATH, Pattern.quote(search), "i"));
+        }
+        return transform(summary, executeFind(and(filters)).limit(Math.min(MAX_NUMBER_ENTITIES, limit == null ? Integer.MAX_VALUE : limit)));
+    }
 
     public List<StoredEntity> findEntitiesByClassifier(String classifier, boolean summary, boolean versioned)
     {
         return transform(summary, executeFind(and(eq(ENTITY_CLASSIFIER_PATH, classifier), eq(VERSIONED_ENTITY, versioned))));
-    }
-
-    @Override
-    public List<StoredEntity> findLatestEntitiesByClassifier(String classifier, boolean summary, boolean versioned)
-    {
-        return transform(summary, executeFind(and(and(eq(ENTITY_CLASSIFIER_PATH, classifier), eq(VERSION_ID, MASTER_SNAPSHOT)), eq(VERSIONED_ENTITY, versioned))));
     }
 
     @Override
@@ -414,9 +437,9 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
 
 
     @Override
-    public StoreOperationResult delete(String groupId, String artifactId, String versionId,boolean versioned)
+    public StoreOperationResult delete(String groupId, String artifactId, String versionId, boolean versioned)
     {
-        Bson filter = and(eq(VERSIONED_ENTITY, versioned),getArtifactAndVersionFilter(groupId, artifactId, versionId));
+        Bson filter = and(eq(VERSIONED_ENTITY, versioned), getArtifactAndVersionFilter(groupId, artifactId, versionId));
         DeleteResult result = getCollection().deleteMany(filter);
         return new StoreOperationResult(0, 0, result.getDeletedCount(), Collections.emptyList());
     }
@@ -467,10 +490,10 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
                 Projections.include(GROUP_ID, ARTIFACT_ID),
                 Projections.computed("coordinate", new BasicDBObject("$concat", concat))));
 
-        getCollection().aggregate(Arrays.asList(allCoordinates, group("$coordinate"))).forEach((Consumer<Document>)document ->
+        getCollection().aggregate(Arrays.asList(allCoordinates, group("$coordinate"))).forEach((Consumer<Document>) document ->
                 {
-                    StringTokenizer tokenizer = new StringTokenizer(document.getString("_id"),":");
-                    result.add(Tuples.pair(tokenizer.nextToken(),tokenizer.nextToken()));
+                    StringTokenizer tokenizer = new StringTokenizer(document.getString("_id"), ":");
+                    result.add(Tuples.pair(tokenizer.nextToken(), tokenizer.nextToken()));
                 }
         );
         return result;

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/projects/ProjectsMongo.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/projects/ProjectsMongo.java
@@ -114,6 +114,11 @@ public class ProjectsMongo extends BaseMongo<ProjectData> implements Projects, U
         return getAllStoredEntities();
     }
 
+    @Override
+    public List<ProjectData> getProjects(int page, int pageSize)
+    {
+        return getStoredEntitiesByPage(page, pageSize);
+    }
 
     @Override
     public Optional<ProjectData> find(String groupId, String artifactId)

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryClassifierPath.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryClassifierPath.java
@@ -1,0 +1,64 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.store.mongo.entities;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.depot.domain.project.ProjectVersion;
+import org.finos.legend.depot.store.mongo.TestStoreMongo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+
+public class TestQueryClassifierPath extends TestStoreMongo
+{
+    private static final URL ENTITIES_FILE = TestUpdateVersions.class.getClassLoader().getResource("data/classifiers.json");
+    private EntitiesMongo mongo = new EntitiesMongo(mongoProvider, getMongoClient());
+
+
+    @Test
+    public void canQuerySnapshotEntitiesByClassifier()
+    {
+        String CPATH = "meta::pure::metamodel::extension::Profile";
+        setUpEntitiesDataFromFile(ENTITIES_FILE);
+        Assert.assertEquals(2, mongo.getRevisionEntityCount("examples.metadata", "test"));
+        Assert.assertEquals(1, mongo.getRevisionEntityCount("examples.metadata", "test2"));
+        Assert.assertEquals(3, mongo.findLatestEntitiesByClassifier(CPATH, null, null, false, false).size());
+        Assert.assertEquals(2, mongo.findLatestEntitiesByClassifier(CPATH, null, 2, false, false).size());
+        Assert.assertEquals(1, mongo.findLatestEntitiesByClassifier(CPATH, "TestProfileTwo", 2, false, false).size());
+    }
+
+    @Test
+    public void canQueryVersionEntitiesByClassifier()
+    {
+        String CPATH = "meta::pure::metamodel::extension::Profile";
+        setUpEntitiesDataFromFile(ENTITIES_FILE);
+        Assert.assertEquals(2, mongo.getRevisionEntityCount("examples.metadata", "test"));
+        Assert.assertEquals(1, mongo.getRevisionEntityCount("examples.metadata", "test2"));
+        Assert.assertEquals(8, mongo.findReleasedEntitiesByClassifier(CPATH, null, null, null, false, false).size());
+        Assert.assertEquals(2, mongo.findReleasedEntitiesByClassifier(CPATH, null, null, 2, false, false).size());
+        Assert.assertEquals(4, mongo.findReleasedEntitiesByClassifier(CPATH, "TestProfileTwo", null, null, false, false).size());
+        Assert.assertEquals(8, mongo.findReleasedEntitiesByClassifier(CPATH, "TestProfile", null, null, false, false).size());
+        Assert.assertEquals(0, mongo.findReleasedEntitiesByClassifier(CPATH, null, Lists.fixedSize.of(new ProjectVersion("examples.metadata", "test", "1.0.0")), null, false, false).size());
+        Assert.assertEquals(2, mongo.findReleasedEntitiesByClassifier(CPATH, null, Lists.fixedSize.of(new ProjectVersion("examples.metadata", "test", "2.2.0")), null, false, false).size());
+        Assert.assertEquals(1, mongo.findReleasedEntitiesByClassifier(CPATH, null, Lists.fixedSize.of(new ProjectVersion("examples.metadata", "test", "2.3.0")), null, false, false).size());
+        Assert.assertEquals(2, mongo.findReleasedEntitiesByClassifier(CPATH, null, Lists.fixedSize.of(new ProjectVersion("examples.metadata", "test2", "2.3.0")), null, false, false).size());
+        Assert.assertEquals(3, mongo.findReleasedEntitiesByClassifier(CPATH, null, Lists.fixedSize.of(new ProjectVersion("examples.metadata", "test", "2.3.0"), new ProjectVersion("examples.metadata", "test2", "2.3.0")), null, false, false).size());
+        Assert.assertEquals(1, mongo.findReleasedEntitiesByClassifier(CPATH, "TestProfileTwo", Lists.fixedSize.of(new ProjectVersion("examples.metadata", "test", "2.3.0")), null, false, false).size());
+        Assert.assertEquals(1, mongo.findReleasedEntitiesByClassifier(CPATH, "TestProfileTwo", Lists.fixedSize.of(new ProjectVersion("examples.metadata", "test2", "2.3.0")), null, false, false).size());
+        Assert.assertEquals(2, mongo.findReleasedEntitiesByClassifier(CPATH, "TestProfileTwo", Lists.fixedSize.of(new ProjectVersion("examples.metadata", "test", "2.3.0"), new ProjectVersion("examples.metadata", "test2", "2.3.0")), null, false, false).size());
+    }
+}

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestUpdateRevisions.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestUpdateRevisions.java
@@ -61,7 +61,7 @@ public class TestUpdateRevisions extends TestStoreMongo
     }
 
     @Test
-    public void updatingSameEntityDoesNotCreateAnewONe()
+    public void updatingSameEntityDoesNotCreateANewOne()
     {
         List<StoredEntity> entitiesList = readEntitiesFile(ENTITIES_FILE);
         Assert.assertNotNull(entitiesList);
@@ -101,7 +101,7 @@ public class TestUpdateRevisions extends TestStoreMongo
         StoredEntity updated = new StoredEntity(entity.getGroupId(),entity.getArtifactId(),entity.getVersionId(), entity.isVersionedEntity(), entityDefinition);
         revisionsMongo.newOrUpdate(null, updated);
 
-        Document doc = (Document)revisionsMongo.getCollection().find().iterator().next();
+        Document doc = (Document) revisionsMongo.getCollection().find().iterator().next();
         Assert.assertNotNull(doc);
         
         Assert.assertEquals(entity.getVersionId(), doc.getString(EntitiesMongo.VERSION_ID));
@@ -132,7 +132,7 @@ public class TestUpdateRevisions extends TestStoreMongo
     public void canQueryByClassifier()
     {
         setUpEntitiesDataFromFile(ENTITIES_FILE);
-        List<StoredEntity> entities = revisionsMongo.findLatestEntitiesByClassifier("meta::pure::metamodel::type::Class", true, true);
+        List<StoredEntity> entities = revisionsMongo.findLatestEntitiesByClassifier("meta::pure::metamodel::type::Class", null, null, true, true);
         Assert.assertNotNull(entities);
         Assert.assertEquals(2, entities.size());
         for (StoredEntity entity : entities)

--- a/legend-depot-store-mongo/src/test/resources/data/classifiers.json
+++ b/legend-depot-store-mongo/src/test/resources/data/classifiers.json
@@ -1,0 +1,204 @@
+[
+  {
+    "versionId": "2.2.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::TestProfile",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfile",
+        "package": "examples::metadata::test"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.2.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::ClientBasic",
+      "classifierPath": "meta::pure::metamodel::type::Class",
+      "content": {
+        "_type": "class",
+        "name": "ClientBasic",
+        "package": "examples::metadata::test",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "Name",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "EntityId",
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IsActive",
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "RiskScore",
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IncorporationDate",
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "OptionalAlternativeName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "newProperty",
+            "type": "String"
+          }
+        ]
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.2.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::subpackage::TestProfileTwo",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfileTwo",
+        "package": "examples::metadata::test::subpackage"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "master-SNAPSHOT",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::TestProfile",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfile",
+        "package": "examples::metadata::test"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "master-SNAPSHOT",
+    "groupId": "examples.metadata",
+    "artifactId": "test2",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::TestProfile",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfile",
+        "package": "examples::metadata::test"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "master-SNAPSHOT",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::subpackage::TestProfileTwo",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfileTwo",
+        "package": "examples::metadata::test::subpackage"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.3.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::subpackage::TestProfileTwo",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfileTwo",
+        "package": "examples::metadata::test::subpackage"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.3.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test2",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::subpackage::TestProfileTwo",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfileTwo",
+        "package": "examples::metadata::test::subpackage"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.3.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test2",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::subpackage::TestProfileThree",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfileTwo",
+        "package": "examples::metadata::test::subpackage"
+      }
+    },
+    "id": ""
+  }
+]


### PR DESCRIPTION
Push the burden of performance onto `mongo` rather than trying to fetch all entities in `mongo` and then filter afterwards. The previous approach puts a heavy burden on memory (my past mistake here 😢), now the `limit` is pushed all the way to `mongo` layer which will expect to yield better performance overall