### PR TITLE
fix-missing-versions-api

### DIFF
--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/ArtifactsModule.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/ArtifactsModule.java
@@ -31,6 +31,7 @@ import org.finos.legend.depot.store.artifacts.api.generation.file.FileGeneration
 import org.finos.legend.depot.store.artifacts.api.status.ManageRefreshStatusService;
 import org.finos.legend.depot.store.artifacts.api.status.RefreshStatusService;
 import org.finos.legend.depot.store.artifacts.resources.ArtifactsResource;
+import org.finos.legend.depot.artifacts.repository.resources.RepositoryResource;
 import org.finos.legend.depot.store.artifacts.services.ArtifactResolverFactory;
 import org.finos.legend.depot.store.artifacts.services.ArtifactsRefreshServiceImpl;
 import org.finos.legend.depot.store.artifacts.services.entities.EntitiesHandlerImpl;

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/ArtifactsRefreshService.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/ArtifactsRefreshService.java
@@ -16,9 +16,6 @@
 package org.finos.legend.depot.store.artifacts.api;
 
 import org.finos.legend.depot.domain.api.MetadataEventResponse;
-import org.finos.legend.depot.store.artifacts.domain.status.VersionMismatch;
-
-import java.util.List;
 
 import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
 
@@ -64,8 +61,6 @@ public interface ArtifactsRefreshService
     void delete(String groupId, String artifactId, String versionId);
 
     boolean createIndexesIfAbsent();
-
-    List<VersionMismatch> findVersionsMismatches();
 
     MetadataEventResponse refreshProjectsWithMissingVersions();
 }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/status/RefreshStatusService.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/status/RefreshStatusService.java
@@ -24,15 +24,15 @@ public interface RefreshStatusService
 {
     RefreshStatus get(String groupId, String artifactId, String version);
 
-    List<RefreshStatus> find(String groupId, String artifactId, String version, Boolean running, LocalDateTime startTimeFrom,LocalDateTime startTimeTo);
+    List<RefreshStatus> find(String groupId, String artifactId, String version, Boolean running, Boolean success, LocalDateTime startTimeFrom,LocalDateTime startTimeTo);
 
     default List<RefreshStatus> getAll()
     {
-        return find(null,null,null,null,null,null);
+        return find(null,null,null,null,null,null,null);
     }
 
     default List<RefreshStatus> find(String groupId, String artifactId, String version, Boolean running)
     {
-        return  find(groupId,artifactId,version,running,null,null);
+        return  find(groupId,artifactId,version,running,null,null,null);
     }
 }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/domain/status/RefreshStatus.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/domain/status/RefreshStatus.java
@@ -17,6 +17,10 @@ package org.finos.legend.depot.store.artifacts.domain.status;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.finos.legend.depot.domain.HasIdentifier;
 import org.finos.legend.depot.domain.api.MetadataEventResponse;
 
@@ -25,13 +29,22 @@ import java.util.Date;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RefreshStatus implements HasIdentifier
 {
+    @JsonProperty
     private String groupId;
+    @JsonProperty
     private String artifactId;
+    @JsonProperty
     private String versionId;
-    private boolean running = false;
+    @JsonProperty
+    private boolean running;
+    @JsonProperty
+    @EqualsExclude
     private MetadataEventResponse response;
+    @JsonProperty
     private Date lastRun;
+    @JsonProperty
     private Date startTime;
+    @JsonProperty
     private long duration;
 
     public RefreshStatus()
@@ -116,7 +129,6 @@ public class RefreshStatus implements HasIdentifier
         this.duration = duration;
     }
 
-
     public RefreshStatus withStartTime(Date startTime)
     {
         this.startTime = startTime;
@@ -136,8 +148,24 @@ public class RefreshStatus implements HasIdentifier
     {
         this.running = false;
         this.lastRun = new Date();
-        this.duration = lastRun.getTime() - startTime.getTime();
+        if (this.startTime != null)
+        {
+            this.duration = lastRun.getTime() - startTime.getTime();
+        }
         this.response = this.response != null ? this.response.combine(response) : response;
         return this;
     }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
 }

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshService.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshService.java
@@ -19,6 +19,7 @@ import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryException;
 import org.finos.legend.depot.artifacts.repository.domain.ArtifactType;
 import org.finos.legend.depot.artifacts.repository.maven.impl.TestMavenArtifactsRepository;
+import org.finos.legend.depot.artifacts.repository.services.RepositoryServices;
 import org.finos.legend.depot.domain.api.MetadataEventResponse;
 import org.finos.legend.depot.domain.api.status.MetadataEventStatus;
 import org.finos.legend.depot.domain.entity.StoredEntity;
@@ -63,6 +64,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.mockito.Mockito.mock;
 
 
 public class TestArtifactsRefreshService extends TestStoreMongo
@@ -86,7 +88,8 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     protected FileGenerationsArtifactsProvider fileGenerationsProvider = new FileGenerationsProvider();
 
     protected ArtifactRepository repository = new TestMavenArtifactsRepository();
-    protected ArtifactsRefreshService artifactsRefreshService = new ArtifactsRefreshServiceImpl(projectsService, refreshStatusStore, repository, artifacts, new IncludeProjectPropertiesConfiguration(properties));
+    protected RepositoryServices repositoryServices = mock(RepositoryServices.class);
+    protected ArtifactsRefreshService artifactsRefreshService = new ArtifactsRefreshServiceImpl(projectsService, refreshStatusStore, repository, repositoryServices, artifacts, new IncludeProjectPropertiesConfiguration(properties));
 
     protected ManageEntitiesService entitiesService = new EntitiesServiceImpl(entitiesStore, projectsService);
 

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/store/mongo/TestMongoStatus.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/store/mongo/TestMongoStatus.java
@@ -15,6 +15,7 @@
 
 package org.finos.legend.depot.store.artifacts.store.mongo;
 
+import org.finos.legend.depot.domain.api.MetadataEventResponse;
 import org.finos.legend.depot.store.artifacts.domain.status.RefreshStatus;
 import org.finos.legend.depot.store.mongo.TestStoreMongo;
 import org.junit.Assert;
@@ -68,19 +69,35 @@ public class TestMongoStatus extends TestStoreMongo
         List<RefreshStatus> allstatuss = refreshStatus.find(null,null,null,null);
         Assert.assertNotNull(allstatuss);
         Assert.assertEquals(4, allstatuss.size());
-        List<RefreshStatus> statusesBeforeLunch = refreshStatus.find(null,null,null,null,aPointInTime.toLocalDate().atStartOfDay(), aPointInTime);
+        List<RefreshStatus> statusesBeforeLunch = refreshStatus.find(null,null,null,null,null,aPointInTime.toLocalDate().atStartOfDay(), aPointInTime);
         Assert.assertNotNull(statusesBeforeLunch);
         Assert.assertEquals(1, statusesBeforeLunch.size());
         Assert.assertEquals("test1.org", statusesBeforeLunch.get(0).getGroupId());
 
-        List<RefreshStatus> afterLunch = refreshStatus.find(null,null,null,null,aPointInTime.withHour(12).withMinute(0).withSecond(1), null);
+        List<RefreshStatus> afterLunch = refreshStatus.find(null,null,null,null,null,aPointInTime.withHour(12).withMinute(0).withSecond(1), null);
         Assert.assertNotNull(afterLunch);
         Assert.assertEquals(3, afterLunch.size());
 
-        List<RefreshStatus> statusInBetween = refreshStatus.find(null,null,null,null,aPointInTime.plusHours(1).plusMinutes(1),aPointInTime.plusHours(2));
+        List<RefreshStatus> statusInBetween = refreshStatus.find(null,null,null,null,null,aPointInTime.plusHours(1).plusMinutes(1),aPointInTime.plusHours(2));
         Assert.assertNotNull(statusInBetween);
         Assert.assertEquals(1, statusInBetween.size());
         Assert.assertEquals("test3.org", statusInBetween.get(0).getGroupId());
+
+
+    }
+
+    @Test
+    public void testFindByStatus()
+    {
+        Assert.assertEquals(0, refreshStatus.getCollection().countDocuments());
+        refreshStatus.createOrUpdate(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0").stopRunning(new MetadataEventResponse()));
+        refreshStatus.createOrUpdate(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.1").stopRunning(new MetadataEventResponse().addError("it failed")));
+        Assert.assertEquals(2, refreshStatus.getCollection().countDocuments());
+
+        Assert.assertEquals(2,refreshStatus.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,null,null,null,null,null).size());
+        Assert.assertEquals("1.0.0",refreshStatus.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,null,null,true,null,null).get(0).getVersionId());
+        Assert.assertEquals("1.0.1",refreshStatus.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,null,null,false,null,null).get(0).getVersionId());
+
 
 
     }

--- a/legend-depot-artifacts-repository-api/pom.xml
+++ b/legend-depot-artifacts-repository-api/pom.xml
@@ -33,11 +33,41 @@
             <groupId>org.finos.legend.depot</groupId>
             <artifactId>legend-depot-model</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-core-services</artifactId>
+        </dependency>
         <!-- DEPOT -->
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/RepositoryModule.java
+++ b/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/RepositoryModule.java
@@ -1,0 +1,32 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.artifacts.repository;
+
+import com.google.inject.PrivateModule;
+import org.finos.legend.depot.artifacts.repository.resources.RepositoryResource;
+import org.finos.legend.depot.artifacts.repository.services.RepositoryServices;
+
+public class RepositoryModule extends PrivateModule
+{
+    @Override
+    protected void configure()
+    {
+       bind(RepositoryResource.class);
+       bind(RepositoryServices.class);
+       expose(RepositoryResource.class);
+       expose(RepositoryServices.class);
+    }
+}

--- a/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/domain/VersionMismatch.java
+++ b/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/domain/VersionMismatch.java
@@ -13,14 +13,17 @@
 //  limitations under the License.
 //
 
-package org.finos.legend.depot.store.artifacts.domain.status;
+package org.finos.legend.depot.artifacts.repository.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VersionMismatch
@@ -35,35 +38,35 @@ public class VersionMismatch
     public List<String> versionsNotInCache = new ArrayList<>();
     @JsonProperty
     public List<String> versionsNotInRepo = new ArrayList<>();
+    @JsonProperty
+    @EqualsExclude
+    public List<String> errors = new ArrayList<>();
 
 
-    public VersionMismatch(String projectId, String groupId, String artifactId, List<String> versionsNotInCache, List<String> versionsNotInRepo)
+    public VersionMismatch(String projectId, String groupId, String artifactId, List<String> versionsNotInCache, List<String> versionsNotInRepo,List<String> errors)
     {
         this.projectId = projectId;
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.versionsNotInCache.addAll(versionsNotInCache);
         this.versionsNotInRepo.addAll(versionsNotInRepo);
+        this.errors.addAll(errors);
+    }
+
+    public VersionMismatch(String projectId, String groupId, String artifactId, List<String> versionsNotInCache, List<String> versionsNotInRepo)
+    {
+        this(projectId,groupId,artifactId,versionsNotInCache,versionsNotInRepo, Collections.emptyList());
     }
 
     @Override
-    public boolean equals(Object o)
+    public boolean equals(Object obj)
     {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass())
-        {
-            return false;
-        }
-        VersionMismatch that = (VersionMismatch) o;
-        return Objects.equals(projectId, that.projectId) && Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId);
+        return EqualsBuilder.reflectionEquals(this, obj);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(projectId, groupId, artifactId);
+        return HashCodeBuilder.reflectionHashCode(this);
     }
 }

--- a/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/resources/RepositoryResource.java
+++ b/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/resources/RepositoryResource.java
@@ -1,0 +1,83 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.artifacts.repository.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
+import org.finos.legend.depot.artifacts.repository.domain.VersionMismatch;
+import org.finos.legend.depot.artifacts.repository.services.RepositoryServices;
+import org.finos.legend.depot.tracing.resources.BaseResource;
+import org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Path("")
+@Api("Repository")
+public class RepositoryResource extends BaseResource
+{
+    private final RepositoryServices repositoryServices;
+    private final ArtifactRepository artifactRepository;
+
+    @Inject
+    public RepositoryResource(RepositoryServices repositoryServices,ArtifactRepository artifactRepository)
+    {
+        this.repositoryServices = repositoryServices;
+        this.artifactRepository = artifactRepository;
+    }
+
+
+
+    @GET
+    @Path("/repository/versions/{groupId}/{artifactId}")
+    @ApiOperation(ResourceLoggingAndTracing.REPOSITORY_PROJECT_VERSIONS)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> getRepositoryVersions(@PathParam("groupId") String groupId,
+                                                 @PathParam("artifactId") String artifactId)
+    {
+        return handle(ResourceLoggingAndTracing.REPOSITORY_PROJECT_VERSIONS, ResourceLoggingAndTracing.REPOSITORY_PROJECT_VERSIONS + groupId + artifactId,
+                () ->
+                {
+                    try
+                    {
+                        return artifactRepository.findVersions(groupId, artifactId).stream().map(v -> v.toVersionIdString()).collect(Collectors.toList());
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                });
+    }
+
+
+    @GET
+    @Path("/repository/versions/mismatch")
+    @ApiOperation(ResourceLoggingAndTracing.GET_PROJECT_CACHE_MISMATCHES)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<VersionMismatch> getVersionMissMatches()
+    {
+        return handle(ResourceLoggingAndTracing.GET_PROJECT_CACHE_MISMATCHES, () -> this.repositoryServices.findVersionsMismatches());
+    }
+
+
+}

--- a/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/services/RepositoryServices.java
+++ b/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/services/RepositoryServices.java
@@ -1,0 +1,77 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.artifacts.repository.services;
+
+import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
+import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryException;
+import org.finos.legend.depot.artifacts.repository.domain.VersionMismatch;
+import org.finos.legend.depot.services.api.projects.ProjectsService;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RepositoryServices
+{
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(RepositoryServices.class);
+
+    private final ArtifactRepository repository;
+    private final ProjectsService projects;
+
+    @Inject
+    public RepositoryServices(ArtifactRepository repository, ProjectsService projectsService)
+    {
+        this.repository = repository;
+        this.projects = projectsService;
+    }
+
+    public List<VersionMismatch> findVersionsMismatches()
+    {
+        List<VersionMismatch> versionMismatches = new ArrayList<>();
+        projects.getAll().forEach(p ->
+        {
+            try
+            {
+                    List<String> repositoryVersions = repository.findVersions(p.getGroupId(), p.getArtifactId()).stream().map(v -> v.toVersionIdString()).collect(Collectors.toList());
+                    Collections.sort(repositoryVersions);
+                    //check versions not in cache
+                    List<String> versionsNotInCache = new ArrayList<>(repositoryVersions);
+                    versionsNotInCache.removeAll(p.getVersions());
+                    //check versions not in repo
+                    List<String> versionsNotInRepo = new ArrayList<>(p.getVersions());
+                    versionsNotInRepo.removeAll(repositoryVersions);
+
+                    if (!versionsNotInCache.isEmpty() || !versionsNotInRepo.isEmpty())
+                    {
+                        versionMismatches.add(new VersionMismatch(p.getProjectId(), p.getGroupId(), p.getArtifactId(), versionsNotInCache, versionsNotInRepo));
+                        LOGGER.info("version-mismatch found for {} {} {} : notInCache [{}], notInRepo [{}]", p.getProjectId(), p.getGroupId(), p.getArtifactId(), versionsNotInCache, versionsNotInRepo);
+                    }
+
+            }
+            catch (ArtifactRepositoryException e)
+            {
+                String message = String.format("Could not get versions for %s:%s exception: %s ",p.getGroupId(),p.getArtifactId(),e.getMessage());
+                LOGGER.error(message);
+                versionMismatches.add(new VersionMismatch(p.getProjectId(), p.getGroupId(), p.getArtifactId(), Collections.emptyList(), Collections.emptyList(), Arrays.asList(message)));
+            }
+        });
+        return versionMismatches;
+    }
+}

--- a/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/server/LegendDepotStoreServer.java
+++ b/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/server/LegendDepotStoreServer.java
@@ -17,6 +17,7 @@ package org.finos.legend.depot.store.server;
 
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import io.dropwizard.setup.Bootstrap;
+import org.finos.legend.depot.artifacts.repository.RepositoryModule;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryProviderConfiguration;
 import org.finos.legend.depot.core.authorisation.AuthorisationModule;
 import org.finos.legend.depot.core.http.BaseServer;
@@ -71,6 +72,7 @@ public class LegendDepotStoreServer extends BaseServer<DepotStoreServerConfigura
                 .modules(new DepotStoreResourcesModule())
                 .modules(new StoreStatusModule())
                 .modules(new ArtifactsModule())
+                .modules(new RepositoryModule())
                 .modules(new TracingModule())
                 .modules(new MetricsModule())
                 .modules(new NotificationsModule())


### PR DESCRIPTION
Included in this PR:
- enhanced  versions mismatches api not fail in exception but rather expose that in the results. This might indicate there is an issue retrieving version from repository and need to be bubbled up.
- moved repository related apis to repository-api module and it own group in swagger. Functionally does not belong with the artifact refresh services.
- added ability to query refresh status by success or failure