### PR TITLE
enhancements-to-refresh

### DIFF
--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/ArtifactsModule.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/ArtifactsModule.java
@@ -117,7 +117,7 @@ public class ArtifactsModule extends PrivateModule
     @Named("update-versions")
     boolean initVersions(SchedulesFactory schedulesFactory, ArtifactsRefreshService artifactsRefreshService, ArtifactRepositoryProviderConfiguration configuration)
     {
-        schedulesFactory.register(UPDATE_VERSIONS_SCHEDULER, LocalDateTime.now().plusHours(2), configuration.getVersionsUpdateIntervalInMillis(), false,() -> artifactsRefreshService.refreshAllVersionsForAllProjects(false));
+        schedulesFactory.register(UPDATE_VERSIONS_SCHEDULER, LocalDateTime.now().plusHours(2), configuration.getVersionsUpdateIntervalInMillis(), false,() -> artifactsRefreshService.refreshAllVersionsForAllProjects(false,false,UPDATE_VERSIONS_SCHEDULER));
         return true;
     }
 
@@ -126,7 +126,7 @@ public class ArtifactsModule extends PrivateModule
     @Named("update-revisions")
     boolean initRevisions(SchedulesFactory schedulesFactory,ArtifactsRefreshService artifactsRefreshService, ArtifactRepositoryProviderConfiguration configuration)
     {
-        schedulesFactory.register(UPDATE_MASTER_REVISIONS_SCHEDULER, LocalDateTime.now().plusHours(1), configuration.getLatestUpdateIntervalInMillis(),false, () -> artifactsRefreshService.refreshMasterSnapshotForAllProjects(false));
+        schedulesFactory.register(UPDATE_MASTER_REVISIONS_SCHEDULER, LocalDateTime.now().plusHours(1), configuration.getLatestUpdateIntervalInMillis(),false, () -> artifactsRefreshService.refreshMasterSnapshotForAllProjects(false,false,UPDATE_MASTER_REVISIONS_SCHEDULER));
         return true;
     }
 
@@ -135,7 +135,7 @@ public class ArtifactsModule extends PrivateModule
     @Named("update-missing-versions")
     boolean initFixVersionsMismatchDaemon(SchedulesFactory schedulesFactory, ArtifactsRefreshService artifactsRefreshService,ArtifactRepositoryProviderConfiguration configuration)
     {
-        schedulesFactory.register(FIX_MISSING_VERSIONS_SCHEDULE, LocalDateTime.now().plusMinutes(5), configuration.getFixVersionsMismatchIntervalInMillis(), false,artifactsRefreshService::refreshProjectsWithMissingVersions);
+        schedulesFactory.register(FIX_MISSING_VERSIONS_SCHEDULE, LocalDateTime.now().plusMinutes(5), configuration.getFixVersionsMismatchIntervalInMillis(), false,() -> artifactsRefreshService.refreshProjectsWithMissingVersions(false,false,FIX_MISSING_VERSIONS_SCHEDULE));
         return true;
     }
 }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/ArtifactsRefreshService.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/ArtifactsRefreshService.java
@@ -21,20 +21,20 @@ import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAP
 
 public interface ArtifactsRefreshService
 {
-    default MetadataEventResponse refreshMasterSnapshotForProject(String groupId, String artifactId, boolean fullUpdate)
+    MetadataEventResponse refreshMasterSnapshotForAllProjects(boolean fullUpdate, boolean transitive,String parentEventId);
+
+    default MetadataEventResponse refreshMasterSnapshotForProject(String groupId, String artifactId, boolean fullUpdate, boolean transitive,String parentEventId)
     {
-        return refreshVersionForProject(groupId,artifactId,MASTER_SNAPSHOT,fullUpdate);
+        return refreshVersionForProject(groupId,artifactId,MASTER_SNAPSHOT,fullUpdate,transitive,parentEventId);
     }
 
-    MetadataEventResponse refreshMasterSnapshotForAllProjects(boolean fullUpdate);
+    MetadataEventResponse refreshVersionForProject(String groupId, String artifactId, String versionId, boolean fullUpdate, boolean transitive, String parentEventId);
 
-    MetadataEventResponse refreshVersionForProject(String groupId, String artifactId, String versionId, boolean fullUpdate);
+    MetadataEventResponse refreshAllVersionsForProject(String groupId, String artifactId, boolean fullUpdate,boolean transitive, String parentEventId);
 
-    MetadataEventResponse refreshVersionForProject(String groupId, String artifactId, String versionId, boolean fullUpdate, String parentEventId);
+    MetadataEventResponse refreshAllVersionsForAllProjects(boolean fullUpdate,boolean transitive, String parentEventId);
 
-    MetadataEventResponse refreshAllVersionsForProject(String groupId, String artifactId, boolean fullUpdate);
-
-    MetadataEventResponse refreshAllVersionsForAllProjects(boolean fullUpdate);
+    MetadataEventResponse refreshProjectsWithMissingVersions(boolean fullUpdate,boolean transitive, String parentEventId);
 
     MetadataEventResponse retireLeastRecentlyUsedVersions(int numberOfDays);
 
@@ -43,7 +43,4 @@ public interface ArtifactsRefreshService
     void delete(String groupId, String artifactId, String versionId);
 
     boolean createIndexesIfAbsent();
-
-    MetadataEventResponse refreshProjectsWithMissingVersions();
-
   }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/domain/status/RefreshStatus.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/domain/status/RefreshStatus.java
@@ -135,9 +135,10 @@ public class RefreshStatus implements HasIdentifier
         return parentEventId;
     }
 
-    public void setParentEventId(String parentEventId)
+    public RefreshStatus setParentEventId(String parentEventId)
     {
         this.parentEventId = parentEventId;
+        return this;
     }
 
     public RefreshStatus withStartTime(Date startTime)

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/resources/ArtifactsResource.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/resources/ArtifactsResource.java
@@ -113,43 +113,47 @@ public class ArtifactsResource extends BaseAuthorisedResource
     public MetadataEventResponse updateProjectVersion(@PathParam("groupId") String groupId,
                                                       @PathParam("artifactId") String artifactId,
                                                       @PathParam("versionId") String versionId,
-                                                      @QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh and its dependencies") boolean fullUpdate)
+                                                      @QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh of processed jar files, versions ,etc") boolean fullUpdate,
+                                                      @QueryParam("transitive") @DefaultValue("false") @ApiParam("Whether to refresh its dependencies") boolean transitive)
     {
-        return handle(ResourceLoggingAndTracing.UPDATE_VERSION, ResourceLoggingAndTracing.UPDATE_VERSION + groupId + artifactId + versionId, () -> artifactsRefreshService.refreshVersionForProject(groupId, artifactId, versionId, fullUpdate));
+        return handle(ResourceLoggingAndTracing.UPDATE_VERSION, ResourceLoggingAndTracing.UPDATE_VERSION + groupId + artifactId + versionId, () -> artifactsRefreshService.refreshVersionForProject(groupId, artifactId, versionId, fullUpdate,transitive,ResourceLoggingAndTracing.UPDATE_VERSION));
     }
 
     @PUT
     @Path("/artifactsRefresh/{groupId}/{artifactId}/versions")
     @ApiOperation(ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS)
     @Produces(MediaType.APPLICATION_JSON)
-    public MetadataEventResponse updateAllProjectVersions(@PathParam("groupId") String groupId,
+    public MetadataEventResponse updateProjectAllVersions(@PathParam("groupId") String groupId,
                                                        @PathParam("artifactId") String artifactId,
-                                                       @QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh and its dependencies") boolean fullUpdate)
+                                                       @QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh of processed jar files, versions ,etc") boolean fullUpdate,
+                                                       @QueryParam("transitive") @DefaultValue("false") @ApiParam("Whether to refresh its dependencies") boolean transitive)
     {
-        return handle(ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS, ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS + groupId + artifactId, () -> artifactsRefreshService.refreshAllVersionsForProject(groupId, artifactId, fullUpdate));
+        return handle(ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS, ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS + groupId + artifactId, () -> artifactsRefreshService.refreshAllVersionsForProject(groupId, artifactId, fullUpdate,transitive,ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS));
     }
 
     @PUT
     @Path("/artifactsRefresh/{groupId}/{artifactId}/latest")
     @ApiOperation(ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION)
     @Produces(MediaType.APPLICATION_JSON)
-    public MetadataEventResponse refreshRevision(@PathParam("groupId") String groupId,
+    public MetadataEventResponse updateProjectRevision(@PathParam("groupId") String groupId,
                                                  @PathParam("artifactId") String artifactId,
-                                                 @QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh and its dependencies") boolean fullUpdate)
+                                                 @QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh of processed jar files, versions ,etc") boolean fullUpdate,
+                                                 @QueryParam("transitive") @DefaultValue("false") @ApiParam("Whether to refresh its dependencies") boolean transitive)
     {
-        return handle(ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION, ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION + groupId + artifactId, () -> artifactsRefreshService.refreshMasterSnapshotForProject(groupId, artifactId,fullUpdate));
+        return handle(ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION, ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION + groupId + artifactId, () -> artifactsRefreshService.refreshMasterSnapshotForProject(groupId, artifactId,fullUpdate,transitive,ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION));
     }
 
     @PUT
     @Path("/artifactsRefresh/versions")
     @ApiOperation(ResourceLoggingAndTracing.UPDATE_ALL_VERSIONS)
     @Produces(MediaType.APPLICATION_JSON)
-    public MetadataEventResponse updateAllVersions(@QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh and its dependencies") boolean fullUpdate)
+    public MetadataEventResponse updateAllProjectsAllVersions(@QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh of processed jar files, versions ,etc") boolean fullUpdate,
+                                                    @QueryParam("transitive") @DefaultValue("false") @ApiParam("Whether to refresh its dependencies") boolean transitive)
     {
         return handle(ResourceLoggingAndTracing.UPDATE_ALL_VERSIONS, () ->
         {
             validateUser();
-            return artifactsRefreshService.refreshAllVersionsForAllProjects(fullUpdate);
+            return artifactsRefreshService.refreshAllVersionsForAllProjects(fullUpdate,transitive,ResourceLoggingAndTracing.UPDATE_ALL_VERSIONS);
         });
     }
 
@@ -158,12 +162,13 @@ public class ArtifactsResource extends BaseAuthorisedResource
     @Path("/artifactsRefresh/latest")
     @ApiOperation(ResourceLoggingAndTracing.UPDATE_ALL_MASTER_REVISIONS)
     @Produces(MediaType.APPLICATION_JSON)
-    public MetadataEventResponse refreshAllLatestRevisions(@QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh and its dependencies") boolean fullUpdate)
+    public MetadataEventResponse refreshAllProjectsAllLatestRevisions(@QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh of processed jar files, versions ,etc") boolean fullUpdate,
+                                                            @QueryParam("transitive") @DefaultValue("false") @ApiParam("Whether to refresh its dependencies") boolean transitive)
     {
         return handle(ResourceLoggingAndTracing.UPDATE_ALL_MASTER_REVISIONS, () ->
         {
             validateUser();
-            return artifactsRefreshService.refreshMasterSnapshotForAllProjects(fullUpdate);
+            return artifactsRefreshService.refreshMasterSnapshotForAllProjects(fullUpdate,transitive,ResourceLoggingAndTracing.UPDATE_ALL_MASTER_REVISIONS);
         });
     }
 
@@ -210,12 +215,13 @@ public class ArtifactsResource extends BaseAuthorisedResource
     @Path("/artifactsRefresh/versions/missing")
     @ApiOperation(ResourceLoggingAndTracing.FIX_MISSING_VERSIONS)
     @Produces(MediaType.APPLICATION_JSON)
-    public MetadataEventResponse fixVersionMissMatches()
+    public MetadataEventResponse updateMissingVersions(@QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh of processed jar files, versions ,etc") boolean fullUpdate,
+                                                       @QueryParam("transitive") @DefaultValue("false") @ApiParam("Whether to refresh its dependencies") boolean transitive)
     {
         return handle(ResourceLoggingAndTracing.FIX_MISSING_VERSIONS, () ->
         {
             validateUser();
-            return this.artifactsRefreshService.refreshProjectsWithMissingVersions();
+            return this.artifactsRefreshService.refreshProjectsWithMissingVersions(fullUpdate,transitive,ResourceLoggingAndTracing.FIX_MISSING_VERSIONS);
         });
 
     }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/services/ArtifactRefreshEventHandler.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/services/ArtifactRefreshEventHandler.java
@@ -54,7 +54,7 @@ public class ArtifactRefreshEventHandler implements NotificationEventHandler
             projects.createOrUpdate(newProject);
             response.addMessage(String.format("New project %s created %s-%s", newProject.getProjectId(), newProject.getGroupId(), newProject.getArtifactId()));
         }
-        return response.combine(artifactsRefreshService.refreshVersionForProject(event.getGroupId(), event.getArtifactId(), event.getVersionId(), event.isFullUpdate(),event.getParentEventId()));
+        return response.combine(artifactsRefreshService.refreshVersionForProject(event.getGroupId(), event.getArtifactId(), event.getVersionId(), event.isFullUpdate(),event.isTransitive(),event.getParentEventId()));
     }
 
     @Override

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/store/mongo/MongoRefreshStatus.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/store/mongo/MongoRefreshStatus.java
@@ -66,6 +66,7 @@ public class MongoRefreshStatus extends BaseMongo<RefreshStatus> implements Mana
     public boolean createIndexesIfAbsent()
     {
         createIndexIfAbsent("running",RUNNING);
+        createIndexIfAbsent("parentId",PARENT_EVENT);
         createIndexIfAbsent("status",RESPONSE_STATUS);
         return createIndexIfAbsent("groupId-artifactId-versionId", GROUP_ID, ARTIFACT_ID, VERSION_ID);
     }

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/store/mongo/TestMongoStatus.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/store/mongo/TestMongoStatus.java
@@ -98,6 +98,21 @@ public class TestMongoStatus extends TestStoreMongo
         Assert.assertEquals("1.0.0",refreshStatus.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,null,null,null,true,null,null).get(0).getVersionId());
         Assert.assertEquals("1.0.1",refreshStatus.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,null,null,null,false,null,null).get(0).getVersionId());
 
+    }
+
+
+    @Test
+    public void testFindByParentId()
+    {
+        Assert.assertEquals(0, refreshStatus.getCollection().countDocuments());
+        refreshStatus.createOrUpdate(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.0").setParentEventId("test"));
+        refreshStatus.createOrUpdate(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.1").setParentEventId("test"));
+        refreshStatus.createOrUpdate(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.2").setParentEventId("test"));
+        refreshStatus.createOrUpdate(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.3").setParentEventId("test1"));
+        Assert.assertEquals(4, refreshStatus.getCollection().countDocuments());
+
+        Assert.assertEquals(3,refreshStatus.find(null,null,null,"test",null,null,null,null).size());
+        Assert.assertEquals(1,refreshStatus.find(null,null,null,"test1",null,null,null,null).size());
 
 
     }

--- a/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/services/RepositoryServices.java
+++ b/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/services/RepositoryServices.java
@@ -15,17 +15,23 @@
 
 package org.finos.legend.depot.artifacts.repository.services;
 
+import org.apache.maven.model.Model;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryException;
+import org.finos.legend.depot.artifacts.repository.domain.ArtifactDependency;
+import org.finos.legend.depot.artifacts.repository.domain.ArtifactType;
 import org.finos.legend.depot.artifacts.repository.domain.VersionMismatch;
 import org.finos.legend.depot.services.api.projects.ProjectsService;
+import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class RepositoryServices
@@ -73,5 +79,30 @@ public class RepositoryServices
             }
         });
         return versionMismatches;
+    }
+
+    public List<VersionId> findVersions(String groupId, String artifactId) throws ArtifactRepositoryException
+    {
+        return this.repository.findVersions(groupId,artifactId);
+    }
+
+    public Set<ArtifactDependency> findDependencies(String groupId, String artifactId, String versionId)
+    {
+        return this.repository.findDependencies(groupId, artifactId, versionId);
+    }
+
+    public Model getPOM(String groupId, String artifactId, String versionId)
+    {
+        return repository.getPOM(groupId, artifactId, versionId);
+    }
+
+    public boolean areValidCoordinates(String groupId, String artifactId)
+    {
+        return this.repository.areValidCoordinates(groupId, artifactId);
+    }
+
+    public List<File> findFiles(ArtifactType type, String groupId, String artifactId, String versionId)
+    {
+        return this.repository.findFiles(type, groupId, artifactId, versionId);
     }
 }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
@@ -43,6 +43,8 @@ public interface ProjectsService
 
     Optional<ProjectData> find(String groupId, String artifactId);
 
+    boolean exists(String groupId, String artifactId, String versionId);
+
     default Set<ProjectVersion> getDependencies(String groupId, String artifactId, String versionId, boolean transitive)
     {
         return getDependencies(Arrays.asList(new ProjectVersion(groupId, artifactId, versionId)), transitive);
@@ -58,4 +60,5 @@ public interface ProjectsService
     }
 
     List<ProjectVersionPlatformDependency> getDependentProjects(String groupId, String artifactId, String versionId);
+
 }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
@@ -106,6 +106,12 @@ public class ProjectsServiceImpl implements ManageProjectsService
     }
 
     @Override
+    public boolean exists(String groupId, String artifactId, String versionId)
+    {
+        return this.find(groupId,artifactId).orElse(new ProjectData()).getVersions().contains(versionId);
+    }
+
+    @Override
     public Optional<VersionId> getLatestVersion(String groupId, String artifactId)
     {
         return getProject(groupId,artifactId).getLatestVersion();

--- a/legend-depot-model/src/main/java/org/finos/legend/depot/domain/project/ProjectData.java
+++ b/legend-depot-model/src/main/java/org/finos/legend/depot/domain/project/ProjectData.java
@@ -198,4 +198,10 @@ public final class ProjectData extends BaseDomain implements HasIdentifier
         this.versions.addAll(Arrays.asList(versionIds));
         return this;
     }
+
+    @JsonIgnore
+    public Optional<String> getVersion(String versionId)
+    {
+        return this.versions.stream().filter(v -> v.equals(versionId)).findFirst();
+    }
 }

--- a/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/NotificationsModule.java
+++ b/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/NotificationsModule.java
@@ -48,7 +48,6 @@ public class NotificationsModule extends PrivateModule
 
         expose(Notifications.class);
         expose(Queue.class);
-        expose(NotificationsManager.class);
         expose(NotificationsManagerResource.class);
     }
 

--- a/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/api/NotificationsManager.java
+++ b/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/api/NotificationsManager.java
@@ -33,5 +33,5 @@ public interface NotificationsManager
 
     Optional<MetadataNotification> findInQueue(String eventId);
 
-    String notify(String projectId, String groupId, String artifactId, String versionId, boolean fullUpdate, int maxRetries);
+    String notify(String projectId, String groupId, String artifactId, String versionId, int maxRetries);
 }

--- a/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/domain/MetadataNotification.java
+++ b/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/domain/MetadataNotification.java
@@ -47,6 +47,7 @@ public class MetadataNotification implements HasIdentifier
     private String artifactId;
     private String versionId;
     private boolean fullUpdate;
+    private boolean transitive;
     private int retries;
     private Date lastUpdated;
     private int maxRetries;
@@ -65,6 +66,7 @@ public class MetadataNotification implements HasIdentifier
                                 @JsonProperty(value = "status") MetadataEventStatus status,
                                 @JsonProperty(value = "errors") List<String> errors,
                                 @JsonProperty(value = "fullUpdate") boolean fullUpdate,
+                                @JsonProperty(value = "transitive") boolean transitive,
                                 @JsonProperty(value = "retries") int retries,
                                 @JsonProperty(value = "maxRetries") int maxRetries)
     {
@@ -80,40 +82,33 @@ public class MetadataNotification implements HasIdentifier
         this.errors = errors;
         this.retries = retries;
         this.fullUpdate = fullUpdate;
+        this.transitive = transitive;
     }
-
-    public MetadataNotification(String projectId,
-                                String groupId,
-                                String artifactId)
-    {
-        this(projectId, groupId, artifactId, null, new Date(), null, null, MetadataEventStatus.NEW, new ArrayList<>(), false, 0, DEFAULT_MAX_RETRIES);
-    }
-
 
     public MetadataNotification(String projectId,
                                 String groupId,
                                 String artifactId,
                                 String versionId,
-                                boolean fullUpdate)
+                                boolean fullUpdate,
+                                boolean transitive)
     {
-        this(projectId, groupId, artifactId, versionId, new Date(), null, null,MetadataEventStatus.NEW, new ArrayList<>(), fullUpdate, 0, DEFAULT_MAX_RETRIES);
+        this(projectId, groupId, artifactId, versionId, new Date(), null, null,MetadataEventStatus.NEW, new ArrayList<>(), fullUpdate,transitive, 0, DEFAULT_MAX_RETRIES);
     }
 
     public MetadataNotification(String projectId, String groupId, String artifactId, String versionId)
     {
-        this(projectId, groupId, artifactId, versionId, new Date(), null, null, MetadataEventStatus.NEW, new ArrayList<>(), false, 0, DEFAULT_MAX_RETRIES);
+        this(projectId, groupId, artifactId, versionId, new Date(), null, null, MetadataEventStatus.NEW, new ArrayList<>(), false,false, 0, DEFAULT_MAX_RETRIES);
     }
 
-    public MetadataNotification(String projectId, String groupId, String artifactId, String versionId, boolean fullUpdate,int maxRetries)
+    public MetadataNotification(String projectId, String groupId, String artifactId, String versionId, boolean fullUpdate, boolean transitive,int maxRetries)
     {
-        this(projectId, groupId, artifactId, versionId, new Date(), null, null,MetadataEventStatus.NEW, new ArrayList<>(), fullUpdate, 0, maxRetries);
+        this(projectId, groupId, artifactId, versionId, new Date(), null, null,MetadataEventStatus.NEW, new ArrayList<>(), fullUpdate,transitive, 0, maxRetries);
     }
 
-    public MetadataNotification(String projectId,String groupId, String artifactId, String versionId, boolean fullUpdate, String parentEvent)
+    public MetadataNotification(String projectId,String groupId, String artifactId, String versionId, boolean fullUpdate,boolean transitive, String parentEvent)
     {
-        this(projectId, groupId, artifactId, versionId, new Date(), null, parentEvent,MetadataEventStatus.NEW, new ArrayList<>(), fullUpdate, 0, DEFAULT_MAX_RETRIES);
+        this(projectId, groupId, artifactId, versionId, new Date(), null, parentEvent,MetadataEventStatus.NEW, new ArrayList<>(), fullUpdate,transitive, 0, DEFAULT_MAX_RETRIES);
     }
-
 
     public String getId()
     {
@@ -212,6 +207,31 @@ public class MetadataNotification implements HasIdentifier
     public void setParentEventId(String parentEventId)
     {
         this.parentEventId = parentEventId;
+    }
+
+    public void setFullUpdate(boolean fullUpdate)
+    {
+        this.fullUpdate = fullUpdate;
+    }
+
+    public boolean isTransitive()
+    {
+        return transitive;
+    }
+
+    public void setTransitive(boolean transitive)
+    {
+        this.transitive = transitive;
+    }
+
+    public void setMaxRetries(int maxRetries)
+    {
+        this.maxRetries = maxRetries;
+    }
+
+    public void setErrors(List<String> errors)
+    {
+        this.errors = errors;
     }
 
     public MetadataNotification increaseRetries()

--- a/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/resources/NotificationsManagerResource.java
+++ b/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/resources/NotificationsManagerResource.java
@@ -105,7 +105,7 @@ public class NotificationsManagerResource extends BaseResource
                              @DefaultValue("3")
                              @ApiParam("Whether to retry operation if it fails") int maxRetries)
     {
-        return handle(ResourceLoggingAndTracing.ENQUEUE_EVENT, () -> notificationsManager.notify(projectId, groupId, artifactId, versionId,false, maxRetries));
+        return handle(ResourceLoggingAndTracing.ENQUEUE_EVENT, () -> notificationsManager.notify(projectId, groupId, artifactId, versionId, maxRetries));
     }
 
 }

--- a/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/services/NotificationsQueueManager.java
+++ b/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/services/NotificationsQueueManager.java
@@ -118,12 +118,12 @@ public final class NotificationsQueueManager implements NotificationsManager
     }
 
     @Override
-    public String notify(String projectId, String groupId, String artifactId, String versionId, boolean fullUpdate, int maxRetries)
+    public String notify(String projectId, String groupId, String artifactId, String versionId, int maxRetries)
     {
         validateMavenCoordinates(projectId, groupId, artifactId);
-        //we create a notification event with fullUpdate flag set to false(ie partial update)
+        //we create a notification event with fullUpdate/transitive flag set to false(ie partial update)
         //this means, it will only process changed jar files and will only handle those entities,etc
-        MetadataNotification event = new MetadataNotification(projectId, groupId, artifactId, versionId, false,maxRetries);
+        MetadataNotification event = new MetadataNotification(projectId, groupId, artifactId, versionId, false,false,maxRetries);
         return queue.push(event);
     }
 

--- a/legend-depot-store-notifications/src/test/java/org/finos/legend/depot/store/notifications/store/mongo/TestQueueMongo.java
+++ b/legend-depot-store-notifications/src/test/java/org/finos/legend/depot/store/notifications/store/mongo/TestQueueMongo.java
@@ -41,9 +41,9 @@ public class TestQueueMongo extends TestStoreMongo
     @Test
     public void canStoreEvents()
     {
-        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST);
-        MetadataNotification event1 = new MetadataNotification(TESTPROJECT_1, TEST, TEST);
-        MetadataNotification event2 = new MetadataNotification(TESTPROJECT_2, TEST, TEST);
+        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST,VERSION);
+        MetadataNotification event1 = new MetadataNotification(TESTPROJECT_1, TEST, TEST,VERSION);
+        MetadataNotification event2 = new MetadataNotification(TESTPROJECT_2, TEST, TEST,"1.0.1");
         MetadataNotification event3 = new MetadataNotification(TESTPROJECT_2, TEST, TEST, VERSION);
         queue.push(event);
         queue.push(event1);
@@ -69,7 +69,7 @@ public class TestQueueMongo extends TestStoreMongo
     public void eventIdIsKeptOnCompletion()
     {
 
-        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST);
+        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST,VERSION);
         queue.push(event);
         List<MetadataNotification> pulled = queue.pullAll();
         Assert.assertNotNull(pulled);
@@ -87,7 +87,7 @@ public class TestQueueMongo extends TestStoreMongo
     @Test
     public void canRetrieveEventById()
     {
-        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST);
+        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST,VERSION);
         String eventId = queue.push(event);
         List<MetadataNotification> events = queue.pullAll();
         eventsMongo.complete(events.get(0));
@@ -108,9 +108,9 @@ public class TestQueueMongo extends TestStoreMongo
     @Test
     public void canQueryContentsOfQueue()
     {
-        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST);
-        MetadataNotification event1 = new MetadataNotification(TESTPROJECT_1, TEST, TEST);
-        MetadataNotification event2 = new MetadataNotification(TESTPROJECT_2, TEST, TEST);
+        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST,VERSION);
+        MetadataNotification event1 = new MetadataNotification(TESTPROJECT_1, TEST, TEST,VERSION);
+        MetadataNotification event2 = new MetadataNotification(TESTPROJECT_2, TEST, TEST,"1.0.1");
         MetadataNotification event3 = new MetadataNotification(TESTPROJECT_2, TEST, TEST, VERSION);
         queue.push(event);
         queue.push(event1);
@@ -125,7 +125,7 @@ public class TestQueueMongo extends TestStoreMongo
     @Test
     public void canRetrieveEventByIdInQueue()
     {
-        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST);
+        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST,VERSION);
         queue.push(event);
 
         List<MetadataNotification> eventList = queue.getAll();
@@ -141,7 +141,7 @@ public class TestQueueMongo extends TestStoreMongo
     @Test
     public void canStoreErrors()
     {
-        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST);
+        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST,VERSION);
         queue.push(event.failEvent().addError("this is an error"));
 
         List<MetadataNotification> eventList = queue.getAll();
@@ -186,7 +186,7 @@ public class TestQueueMongo extends TestStoreMongo
     @Test
     public void doesNotInsertDuplicateEvents()
     {
-        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST);
+        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST,VERSION);
         String id = queue.push(event);
         Assert.assertNotNull(id);
         String id2 = queue.push(event);
@@ -197,8 +197,8 @@ public class TestQueueMongo extends TestStoreMongo
     @Test
     public void canGetFirstInQueue()
     {
-        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST);
-        MetadataNotification event1 = new MetadataNotification(TESTPROJECT_2, TEST, TEST);
+        MetadataNotification event = new MetadataNotification(TESTPROJECT, TEST, TEST,VERSION);
+        MetadataNotification event1 = new MetadataNotification(TESTPROJECT_2, TEST, TEST,VERSION);
         queue.push(event);
         queue.push(event1);
 


### PR DESCRIPTION
- leverage queue to scale and distribute refresh work

- introduce transitive flag so that dependencies are only updated transitively if true.

- when flag is false we check the dependency project had been previously loaded into store and raise an error otherwise
