### PR TITLE
retire old versions purge api

### DIFF
--- a/legend-depot-artifacts-purge/pom.xml
+++ b/legend-depot-artifacts-purge/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright 2021 Goldman Sachs
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>legend-depot</artifactId>
+        <groupId>org.finos.legend.depot</groupId>
+        <version>1.4.19-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Legend Depot - Artifacts - Purge</name>
+    <artifactId>legend-depot-artifacts-purge</artifactId>
+
+    <dependencies>
+        <!-- DEPOT -->
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-artifacts-refresh</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-core-authorisation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-artifacts-repository-maven-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-core-services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-store-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-store-mongo</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- DEPOT -->
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.bwaldvogel</groupId>
+            <artifactId>mongo-java-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/legend-depot-artifacts-purge/src/main/java/org/finos/legend/depot/store/artifacts/purge/ArtifactsPurgeModule.java
+++ b/legend-depot-artifacts-purge/src/main/java/org/finos/legend/depot/store/artifacts/purge/ArtifactsPurgeModule.java
@@ -1,0 +1,33 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.store.artifacts.purge;
+
+import com.google.inject.PrivateModule;
+import org.finos.legend.depot.store.artifacts.purge.api.ArtifactsPurgeService;
+import org.finos.legend.depot.store.artifacts.purge.resources.ArtifactsPurgeResource;
+import org.finos.legend.depot.store.artifacts.purge.services.ArtifactsPurgeServiceImpl;
+
+public class ArtifactsPurgeModule extends PrivateModule
+{
+    @Override
+    protected void configure()
+    {
+        bind(ArtifactsPurgeResource.class);
+        expose(ArtifactsPurgeResource.class);
+
+        bind(ArtifactsPurgeService.class).to(ArtifactsPurgeServiceImpl.class);
+    }
+}

--- a/legend-depot-artifacts-purge/src/main/java/org/finos/legend/depot/store/artifacts/purge/api/ArtifactsPurgeService.java
+++ b/legend-depot-artifacts-purge/src/main/java/org/finos/legend/depot/store/artifacts/purge/api/ArtifactsPurgeService.java
@@ -1,0 +1,28 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.store.artifacts.purge.api;
+
+import org.finos.legend.depot.domain.api.MetadataEventResponse;
+
+public interface ArtifactsPurgeService
+{
+    MetadataEventResponse deleteLeastRecentlyUsedVersions(int numberOfDays);
+
+    MetadataEventResponse deleteOldestProjectVersions(String groupId, String artifactId, int versionsToKeep);
+
+    void delete(String groupId, String artifactId, String versionId);
+
+  }

--- a/legend-depot-artifacts-purge/src/main/java/org/finos/legend/depot/store/artifacts/purge/resources/ArtifactsPurgeResource.java
+++ b/legend-depot-artifacts-purge/src/main/java/org/finos/legend/depot/store/artifacts/purge/resources/ArtifactsPurgeResource.java
@@ -1,0 +1,94 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.store.artifacts.purge.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.finos.legend.depot.core.authorisation.api.AuthorisationProvider;
+import org.finos.legend.depot.core.authorisation.resources.BaseAuthorisedResource;
+import org.finos.legend.depot.domain.api.MetadataEventResponse;
+import org.finos.legend.depot.store.artifacts.purge.api.ArtifactsPurgeService;
+import org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.security.Principal;
+
+
+@Path("")
+@Api("Artifacts Purge")
+public class ArtifactsPurgeResource extends BaseAuthorisedResource
+{
+    public static final String ARTIFACTS_RESOURCE = "ArtifactsPurge";
+    private final ArtifactsPurgeService artifactsPurgeService;
+
+    @Inject
+    public ArtifactsPurgeResource(ArtifactsPurgeService artifactsPurgeService,
+                                  AuthorisationProvider authorisationProvider,
+                                  @Named("requestPrincipal") Provider<Principal> principalProvider)
+    {
+        super(authorisationProvider, principalProvider);
+        this.artifactsPurgeService = artifactsPurgeService;
+    }
+
+
+    @DELETE
+    @Path("/artifactDelete/{groupId}/{artifactId}/versions/{versionId}")
+    @ApiOperation(ResourceLoggingAndTracing.PURGE_VERSION)
+    @Produces(MediaType.APPLICATION_JSON)
+    public MetadataEventResponse purgeVersion(@PathParam("groupId") String groupId,
+                                              @PathParam("artifactId") String artifactId,
+                                              @PathParam("versionId") String versionId)
+    {
+
+        return handle(ResourceLoggingAndTracing.PURGE_VERSION, () ->
+        {
+            validateUser();
+            artifactsPurgeService.delete(groupId, artifactId, versionId);
+            return new MetadataEventResponse();
+        });
+    }
+
+
+    @DELETE
+    @Path("/artifactDelete/{groupId}/{artifactId}/old/{keepVersions}")
+    @ApiOperation(ResourceLoggingAndTracing.PURGE_OLD_VERSIONS)
+    @Produces(MediaType.APPLICATION_JSON)
+    public MetadataEventResponse purgeOldVersions(@PathParam("groupId") String groupId,
+                                              @PathParam("artifactId") String artifactId,
+                                                  @PathParam("keepVersions") int versionsToKeep)
+    {
+
+        return handle(ResourceLoggingAndTracing.PURGE_OLD_VERSIONS, () ->
+        {
+            validateUser();
+            return artifactsPurgeService.deleteOldestProjectVersions(groupId, artifactId,versionsToKeep);
+        });
+    }
+
+    @Override
+    protected String getResourceName()
+    {
+        return ARTIFACTS_RESOURCE;
+    }
+
+}

--- a/legend-depot-artifacts-purge/src/main/java/org/finos/legend/depot/store/artifacts/purge/services/ArtifactsPurgeServiceImpl.java
+++ b/legend-depot-artifacts-purge/src/main/java/org/finos/legend/depot/store/artifacts/purge/services/ArtifactsPurgeServiceImpl.java
@@ -1,0 +1,150 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.store.artifacts.purge.services;
+
+import org.finos.legend.depot.artifacts.repository.domain.ArtifactType;
+import org.finos.legend.depot.domain.api.MetadataEventResponse;
+import org.finos.legend.depot.domain.project.ProjectData;
+import org.finos.legend.depot.services.api.projects.ManageProjectsService;
+import org.finos.legend.depot.store.artifacts.api.ProjectArtifactsHandler;
+import org.finos.legend.depot.store.artifacts.purge.api.ArtifactsPurgeService;
+import org.finos.legend.depot.store.artifacts.services.ArtifactHandlerFactory;
+import org.finos.legend.depot.tracing.services.TracerFactory;
+import org.finos.legend.depot.tracing.services.prometheus.PrometheusMetricsFactory;
+import org.finos.legend.sdlc.domain.model.version.VersionId;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.PURGE_VERSION;
+
+
+public class ArtifactsPurgeServiceImpl implements ArtifactsPurgeService
+{
+    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ArtifactsPurgeServiceImpl.class);
+    private static final String SEPARATOR = "-";
+    private static final String GROUP_ID = "groupId";
+    private static final String ARTIFACT_ID = "artifactId";
+    private static final String VERSION_ID = "versionId";
+
+    public static final String VERSION_PURGE_COUNTER = "versionPurge";
+    private static final String PURGE_OLDEST = "purge_old";
+
+    private final ManageProjectsService projects;
+
+
+    @Inject
+    public ArtifactsPurgeServiceImpl(ManageProjectsService projects)
+    {
+        this.projects = projects;
+    }
+
+
+    private Set<ArtifactType> getSupportedArtifactTypes()
+    {
+        return ArtifactHandlerFactory.getSupportedTypes();
+    }
+
+    private void decorateSpanWithVersionInfo(String groupId,String artifactId, String versionId)
+    {
+        Map<String, String> tags = new HashMap<>();  
+        tags.put(GROUP_ID, groupId);
+        tags.put(ARTIFACT_ID, artifactId);
+        tags.put(VERSION_ID, versionId);
+        TracerFactory.get().addTags(tags);
+    }
+
+    private ProjectData getProject(String groupId, String artifactId)
+    {
+        Optional<ProjectData> found = projects.find(groupId, artifactId);
+        if (!found.isPresent())
+        {
+            throw new IllegalArgumentException("can't find project for " + groupId + SEPARATOR + artifactId);
+        }
+        return found.get();
+    }
+
+    @Override
+    public void delete(String groupId, String artifactId, String versionId)
+    {
+        decorateSpanWithVersionInfo(groupId, artifactId, versionId);
+        TracerFactory.get().executeWithTrace(PURGE_VERSION, () ->
+        {
+            getSupportedArtifactTypes().forEach(artifactType ->
+            {
+                ProjectArtifactsHandler artifactHandler = ArtifactHandlerFactory.getArtifactHandler(artifactType);
+                if (artifactHandler != null)
+                {
+                    artifactHandler.delete(groupId, artifactId, versionId);
+                }
+            });
+            ProjectData project = getProject(groupId, artifactId);
+            project.removeVersion(versionId);
+            PrometheusMetricsFactory.getInstance().incrementCount(VERSION_PURGE_COUNTER);
+            return projects.createOrUpdate(project);
+        });
+    }
+
+    @Override
+    public MetadataEventResponse deleteOldestProjectVersions(String groupId, String artifactId, int versionsToKeep)
+    {
+        return deleteOldestProjectVersions(getProject(groupId, artifactId),versionsToKeep);
+    }
+
+    private MetadataEventResponse deleteOldestProjectVersions(ProjectData project, int versionsToKeep)
+    {
+        return TracerFactory.get().executeWithTrace(PURGE_OLDEST, () ->
+        {
+            MetadataEventResponse response = new MetadataEventResponse();
+            List<VersionId> versionIds = project.getVersionsOrdered();
+            int numberOfVersions = versionIds.size();
+            try
+            {
+                while (versionIds.size() > versionsToKeep)
+                {
+                    VersionId versionId = versionIds.get(0);
+                    delete(project.getGroupId(), project.getArtifactId(), versionId.toVersionIdString());
+                    versionIds.remove(versionId);
+                    project.removeVersion(versionId.toVersionIdString());
+                    response.addMessage(String.format("%s-%s-%s purge", project.getGroupId(), project.getArtifactId(), versionId.toVersionIdString()));
+                    PrometheusMetricsFactory.getInstance().incrementCount(VERSION_PURGE_COUNTER);
+                }
+                projects.createOrUpdate(project);
+                response.addMessage(String.format("%s-%s purged %s versions", project.getGroupId(), project.getArtifactId(), numberOfVersions - versionIds.size()));
+            }
+            catch (Exception e)
+            {
+                 String errorMessage = String.format(" Error purging old versions %s-%s %s",project.getGroupId(),project.getArtifactId(),e.getMessage());
+                 LOGGER.error(errorMessage);
+                 response.addError(errorMessage);
+                 PrometheusMetricsFactory.getInstance().incrementErrorCount(VERSION_PURGE_COUNTER);
+            }
+            return response;
+        });
+    }
+
+    @Override
+    public MetadataEventResponse deleteLeastRecentlyUsedVersions(int numberOfDays)
+    {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+}

--- a/legend-depot-artifacts-purge/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsPurgeService.java
+++ b/legend-depot-artifacts-purge/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsPurgeService.java
@@ -1,0 +1,171 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.store.artifacts.services;
+
+import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
+import org.finos.legend.depot.artifacts.repository.domain.ArtifactType;
+import org.finos.legend.depot.domain.api.MetadataEventResponse;
+import org.finos.legend.depot.domain.project.ProjectData;
+import org.finos.legend.depot.services.api.entities.ManageEntitiesService;
+import org.finos.legend.depot.services.api.projects.ManageProjectsService;
+import org.finos.legend.depot.services.entities.EntitiesServiceImpl;
+import org.finos.legend.depot.services.generation.file.FileGenerationsServiceImpl;
+import org.finos.legend.depot.services.projects.ProjectsServiceImpl;
+import org.finos.legend.depot.store.api.entities.UpdateEntities;
+import org.finos.legend.depot.store.api.generation.file.UpdateFileGenerations;
+import org.finos.legend.depot.store.api.projects.UpdateProjects;
+import org.finos.legend.depot.store.artifacts.purge.api.ArtifactsPurgeService;
+import org.finos.legend.depot.store.artifacts.purge.services.ArtifactsPurgeServiceImpl;
+import org.finos.legend.depot.store.artifacts.services.entities.EntitiesHandlerImpl;
+import org.finos.legend.depot.store.artifacts.services.entities.EntityProvider;
+import org.finos.legend.depot.store.artifacts.services.entities.VersionedEntitiesHandlerImpl;
+import org.finos.legend.depot.store.artifacts.services.entities.VersionedEntityProvider;
+import org.finos.legend.depot.store.artifacts.services.file.FileGenerationHandlerImpl;
+import org.finos.legend.depot.store.artifacts.services.file.FileGenerationsProvider;
+import org.finos.legend.depot.store.mongo.TestStoreMongo;
+import org.finos.legend.depot.store.mongo.entities.EntitiesMongo;
+import org.finos.legend.depot.store.mongo.generation.file.FileGenerationsMongo;
+
+import org.finos.legend.depot.store.mongo.projects.ProjectsMongo;
+import org.finos.legend.sdlc.domain.model.version.VersionId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.mockito.Mockito.mock;
+
+
+public class TestArtifactsPurgeService extends TestStoreMongo
+{
+
+    public static final String TEST_GROUP_ID = "examples.metadata";
+    public static final String TEST_ARTIFACT_ID = "test";
+
+    protected UpdateProjects projectsStore = new ProjectsMongo(mongoProvider);
+    protected ManageProjectsService projectsService = new ProjectsServiceImpl(projectsStore);
+    protected UpdateEntities entitiesStore = new EntitiesMongo(mongoProvider);
+    protected UpdateFileGenerations fileGenerationsStore = new FileGenerationsMongo(mongoProvider);
+
+    protected ManageEntitiesService entitiesService = new EntitiesServiceImpl(entitiesStore, projectsService);
+    protected ArtifactsPurgeService purgeService = new ArtifactsPurgeServiceImpl(projectsService);
+
+
+
+    @Before
+    public void setUpData()
+    {
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.ENTITIES, new EntitiesHandlerImpl(entitiesService, mock(EntityProvider.class)));
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.FILE_GENERATIONS, new FileGenerationHandlerImpl(mock(ArtifactRepository.class), mock(FileGenerationsProvider.class), new FileGenerationsServiceImpl(fileGenerationsStore, entitiesStore, projectsService)));
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.VERSIONED_ENTITIES, new VersionedEntitiesHandlerImpl(new EntitiesServiceImpl(entitiesStore, projectsService), mock(VersionedEntityProvider.class)));
+
+        setUpProjectsFromFile(TestArtifactsPurgeService.class.getClassLoader().getResource("data/projects.json"));
+        Assert.assertEquals(3, projectsStore.getAll().size());
+
+        setUpEntitiesDataFromFile(TestArtifactsPurgeService.class.getClassLoader().getResource("data/entities.json"));
+        setUpFileGenerationFromFile(TestArtifactsPurgeService.class.getClassLoader().getResource("data/generations.json"));
+    }
+
+
+    @Test
+    public void canPurgeOldVersions()
+    {
+
+        ProjectData project = projectsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID).get();
+        Assert.assertNotNull(project);
+        List<VersionId> projectVersions = project.getVersionsOrdered();
+        Assert.assertEquals(3, projectVersions.size());
+        Assert.assertEquals("2.0.0", projectVersions.get(0).toVersionIdString());
+        Assert.assertEquals("2.3.0", projectsService.getLatestVersion(TEST_GROUP_ID, TEST_ARTIFACT_ID).get().toVersionIdString());
+
+        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.0.0", false).size());
+        purgeService.deleteOldestProjectVersions(TEST_GROUP_ID,TEST_ARTIFACT_ID,1);
+
+
+        ProjectData after = projectsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID).get();
+        Assert.assertNotNull(after);
+        List<VersionId> afterVersionsOrdered = after.getVersionsOrdered();
+        Assert.assertEquals(1, afterVersionsOrdered.size());
+        Assert.assertFalse(after.getVersions().contains("2.0.0"));
+        Assert.assertFalse(after.getVersions().contains("2.2.0"));
+        Assert.assertTrue(after.getVersions().contains("2.3.0"));
+        Assert.assertEquals(0, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.0.0", false).size());
+        Assert.assertEquals(0, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.2.0", false).size());
+        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.3.0", false).size());
+    }
+
+    @Test
+    public void canPurgeOldVersionsKeepMoreThanExists()
+    {
+
+        ProjectData project = projectsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID).get();
+        Assert.assertNotNull(project);
+        List<VersionId> projectVersions = project.getVersionsOrdered();
+        Assert.assertEquals(3, projectVersions.size());
+        MetadataEventResponse response = purgeService.deleteOldestProjectVersions(TEST_GROUP_ID,TEST_ARTIFACT_ID,5);
+        Assert.assertNotNull(response);
+        ProjectData after = projectsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID).get();
+        Assert.assertNotNull(after);
+        List<VersionId> afterVersionsOrdered = after.getVersionsOrdered();
+        Assert.assertEquals(3, afterVersionsOrdered.size());
+        Assert.assertTrue(after.getVersions().contains("2.0.0"));
+        Assert.assertTrue(after.getVersions().contains("2.2.0"));
+        Assert.assertTrue(after.getVersions().contains("2.3.0"));
+        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.0.0", false).size());
+        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.2.0", false).size());
+        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.3.0", false).size());
+    }
+
+    @Test
+    public void canPurgeOldVersionsNotEnoughVersionsToKeep()
+    {
+
+        ProjectData project = projectsStore.find(TEST_GROUP_ID,"test1").get();
+        Assert.assertNotNull(project);
+        List<VersionId> projectVersions = project.getVersionsOrdered();
+        Assert.assertEquals(0, projectVersions.size());
+        Assert.assertEquals(1, entitiesStore.getEntities(TEST_GROUP_ID, "test1", MASTER_SNAPSHOT, false).size());
+
+        MetadataEventResponse response = purgeService.deleteOldestProjectVersions(TEST_GROUP_ID,"test1",1);
+        Assert.assertNotNull(response);
+        ProjectData after = projectsStore.find(TEST_GROUP_ID,"test1").get();
+        Assert.assertNotNull(after);
+        List<VersionId> afterVersionsOrdered = after.getVersionsOrdered();
+        Assert.assertEquals(0, afterVersionsOrdered.size());
+
+        Assert.assertEquals(1, entitiesStore.getEntities(TEST_GROUP_ID, "test1", MASTER_SNAPSHOT, false).size());
+    }
+
+    @Test
+    public void canDeleteVersion()
+    {
+        String versionId = "2.0.0";
+
+        Assert.assertEquals(2, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, versionId).size());
+        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, versionId,false).size());
+        Assert.assertEquals(0, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, versionId,true).size());
+        Assert.assertEquals(3, fileGenerationsStore.getAll().size());
+
+        purgeService.delete(TEST_GROUP_ID, TEST_ARTIFACT_ID, versionId);
+        Assert.assertEquals(0, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, versionId,false).size());
+        Assert.assertEquals(0, entitiesStore.getEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, versionId,true).size());
+        Assert.assertEquals(0, fileGenerationsStore.find(TEST_GROUP_ID, TEST_ARTIFACT_ID, versionId).size());
+        Assert.assertFalse(projectsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID).get().getVersions().contains(versionId));
+    }
+
+}

--- a/legend-depot-artifacts-purge/src/test/resources/data/entities.json
+++ b/legend-depot-artifacts-purge/src/test/resources/data/entities.json
@@ -1,0 +1,420 @@
+[
+  {
+    "versionId": "2.2.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::TestProfile",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfile",
+        "package": "examples::metadata::test"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.2.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::ClientBasic",
+      "classifierPath": "meta::pure::metamodel::type::Class",
+      "content": {
+        "_type": "class",
+        "name": "ClientBasic",
+        "package": "examples::metadata::test",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "Name",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "EntityId",
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IsActive",
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "RiskScore",
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IncorporationDate",
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "OptionalAlternativeName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "newProperty",
+            "type": "String"
+          }
+        ]
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.3.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::TestProfile",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfile",
+        "package": "examples::metadata::test"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.3.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::ClientBasic",
+      "classifierPath": "meta::pure::metamodel::type::Class",
+      "content": {
+        "_type": "class",
+        "name": "ClientBasic",
+        "package": "examples::metadata::test",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "Name",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "EntityId",
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IsActive",
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "RiskScore",
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IncorporationDate",
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "OptionalAlternativeName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "newProperty",
+            "type": "String"
+          }
+        ]
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.0.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::TestProfile",
+      "classifierPath": "meta::pure::metamodel::extension::Profile",
+      "content": {
+        "_type": "profile",
+        "name": "TestProfile",
+        "package": "examples::metadata::test"
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "2.0.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::ClientBasic",
+      "classifierPath": "meta::pure::metamodel::type::Class",
+      "content": {
+        "_type": "class",
+        "name": "ClientBasic",
+        "package": "examples::metadata::test",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "Name",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "EntityId",
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IsActive",
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "RiskScore",
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IncorporationDate",
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "OptionalAlternativeName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "newProperty",
+            "type": "String"
+          }
+        ]
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "1.0.0",
+    "groupId": "examples.metadata",
+    "artifactId": "test-dependencies",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::ClientBasicDep",
+      "classifierPath": "meta::pure::metamodel::type::Class",
+      "content": {
+        "_type": "class",
+        "name": "ClientBasicDep",
+        "package": "examples::metadata::test",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "Name",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "EntityId",
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IsActive",
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "RiskScore",
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IncorporationDate",
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "OptionalAlternativeName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "newProperty",
+            "type": "String"
+          }
+        ]
+      }
+    },
+    "id": ""
+  },
+  {
+    "versionId": "master-SNAPSHOT",
+    "groupId": "examples.metadata",
+    "artifactId": "test1",
+    "versionedEntity": false,
+    "entity": {
+      "path": "examples::metadata::test::ClientBasicTwo",
+      "classifierPath": "meta::pure::metamodel::type::Class",
+      "content": {
+        "_type": "class",
+        "name": "ClientBasicTwo",
+        "package": "examples::metadata::test",
+        "properties": [
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "Name",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "EntityId",
+            "type": "Integer"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IsActive",
+            "type": "Boolean"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "RiskScore",
+            "type": "Float"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "IncorporationDate",
+            "type": "StrictDate"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "OptionalAlternativeName",
+            "type": "String"
+          },
+          {
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "newProperty",
+            "type": "String"
+          }
+        ]
+      }
+    },
+    "id": ""
+  }
+]

--- a/legend-depot-artifacts-purge/src/test/resources/data/generations.json
+++ b/legend-depot-artifacts-purge/src/test/resources/data/generations.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": null,
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionId": "2.0.0",
+    "path": null,
+    "type": null,
+    "file": {
+      "content": "Some output",
+      "path": "/examples/generated/test/other/MyOutput.json"
+    }
+  },
+  {
+    "id": null,
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionId": "2.2.0",
+    "path": null,
+    "type": null,
+    "file": {
+      "content": "Some output",
+      "path": "/examples/generated/test/other/MyOutput.json"
+    }
+  },
+  {
+    "id": null,
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versionId": "2.3.0",
+    "path": null,
+    "type": null,
+    "file": {
+      "content": "Some output",
+      "path": "/examples/generated/test/other/MyOutput.json"
+    }
+  }
+
+]

--- a/legend-depot-artifacts-purge/src/test/resources/data/projects.json
+++ b/legend-depot-artifacts-purge/src/test/resources/data/projects.json
@@ -1,0 +1,55 @@
+[
+  {
+    "projectId": "PROD-A",
+    "groupId": "examples.metadata",
+    "artifactId": "test",
+    "versions": [
+      "2.0.0",
+      "2.2.0",
+      "2.3.0"
+    ],
+    "dependencies": [
+      {
+        "projectId": "PROD-A",
+        "versionId": "master-SNAPSHOT",
+        "groupId": "examples.metadata",
+        "artifactId": "test",
+        "dependency": {
+          "projectId": "PROD-B",
+          "groupId": "examples.metadata",
+          "artifactId": "test-dependencies",
+          "versionId": "1.0.0"
+        }
+      },
+      {
+        "projectId": "PROD-A",
+        "versionId": "2.3.1",
+        "groupId": "examples.metadata",
+        "artifactId": "test",
+        "dependency": {
+          "projectId": "PROD-B",
+          "groupId": "examples.metadata",
+          "artifactId": "test-dependencies",
+          "versionId": "1.0.0"
+        }
+      }
+    ]
+  },
+  {
+    "projectId": "PROD-B",
+    "groupId": "examples.metadata",
+    "artifactId": "test-dependencies",
+    "versions": [
+      "1.0.0"
+    ],
+    "dependencies": []
+  },
+  {
+    "projectId": "PROD-C",
+    "groupId": "examples.metadata",
+    "artifactId": "test1",
+    "versions": [
+    ],
+    "dependencies": []
+  }
+]

--- a/legend-depot-artifacts-purge/src/test/resources/logback-test.xml
+++ b/legend-depot-artifacts-purge/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<!--
+  ~  Copyright 2021 Goldman Sachs
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
+        </encoder>
+    </appender>
+    <root level="OFF">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+    <logger name="org,finos.legend.depot" level="OFF" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+    <logger name="org.jboss.shrinkwrap" level="OFF" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+</configuration>

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/ArtifactsModule.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/ArtifactsModule.java
@@ -18,137 +18,67 @@ package org.finos.legend.depot.store.artifacts;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryProviderConfiguration;
 import org.finos.legend.depot.artifacts.repository.domain.ArtifactType;
-import org.finos.legend.depot.store.admin.services.schedules.SchedulesFactory;
-import org.finos.legend.depot.store.artifacts.api.ArtifactsRefreshService;
 import org.finos.legend.depot.store.artifacts.api.entities.EntitiesArtifactsHandler;
 import org.finos.legend.depot.store.artifacts.api.entities.EntityArtifactsProvider;
 import org.finos.legend.depot.store.artifacts.api.entities.VersionedEntitiesArtifactsHandler;
 import org.finos.legend.depot.store.artifacts.api.entities.VersionedEntityArtifactsProvider;
 import org.finos.legend.depot.store.artifacts.api.generation.file.FileGenerationsArtifactsHandler;
 import org.finos.legend.depot.store.artifacts.api.generation.file.FileGenerationsArtifactsProvider;
-import org.finos.legend.depot.store.artifacts.api.status.ManageRefreshStatusService;
-import org.finos.legend.depot.store.artifacts.api.status.RefreshStatusService;
-import org.finos.legend.depot.store.artifacts.resources.ArtifactsResource;
-import org.finos.legend.depot.store.artifacts.services.ArtifactRefreshEventHandler;
-import org.finos.legend.depot.store.artifacts.services.ArtifactResolverFactory;
-import org.finos.legend.depot.store.artifacts.services.ArtifactsRefreshServiceImpl;
+import org.finos.legend.depot.store.artifacts.services.ArtifactHandlerFactory;
 import org.finos.legend.depot.store.artifacts.services.entities.EntitiesHandlerImpl;
 import org.finos.legend.depot.store.artifacts.services.entities.EntityProvider;
 import org.finos.legend.depot.store.artifacts.services.entities.VersionedEntitiesHandlerImpl;
 import org.finos.legend.depot.store.artifacts.services.entities.VersionedEntityProvider;
 import org.finos.legend.depot.store.artifacts.services.file.FileGenerationHandlerImpl;
 import org.finos.legend.depot.store.artifacts.services.file.FileGenerationsProvider;
-import org.finos.legend.depot.store.artifacts.store.mongo.ArtifactsMongo;
-import org.finos.legend.depot.store.artifacts.store.mongo.MongoRefreshStatus;
-import org.finos.legend.depot.store.artifacts.store.mongo.api.UpdateArtifacts;
-import org.finos.legend.depot.store.notifications.api.NotificationEventHandler;
-import org.finos.legend.depot.tracing.api.PrometheusMetricsHandler;
 
 import javax.inject.Named;
-import java.time.LocalDateTime;
 
 public class ArtifactsModule extends PrivateModule
 {
-    private static final String UPDATE_MASTER_REVISIONS_SCHEDULER = "refreshVersionArtifacts-master-revisions-scheduler";
-    private static final String UPDATE_VERSIONS_SCHEDULER = "refreshVersionArtifacts-versions-scheduler";
-    private static final String FIX_MISSING_VERSIONS_SCHEDULE = "fix-missing-versions-schedule";
-
     @Override
     protected void configure()
     {
-        bind(ArtifactsResource.class);
-        bind(UpdateArtifacts.class).to(ArtifactsMongo.class);
-        bind(ManageRefreshStatusService.class).to(MongoRefreshStatus.class);
-        bind(RefreshStatusService.class).to(MongoRefreshStatus.class);
-
-        bind(EntitiesArtifactsHandler.class).to(EntitiesHandlerImpl.class);
         bind(EntityArtifactsProvider.class).to(EntityProvider.class);
-
-        bind(VersionedEntitiesArtifactsHandler.class).to(VersionedEntitiesHandlerImpl.class);
         bind(VersionedEntityArtifactsProvider.class).to(VersionedEntityProvider.class);
-
-        bind(FileGenerationsArtifactsHandler.class).to(FileGenerationHandlerImpl.class);
         bind(FileGenerationsArtifactsProvider.class).to(FileGenerationsProvider.class);
 
-        bind(ArtifactsRefreshService.class).to(ArtifactsRefreshServiceImpl.class);
-        bind(NotificationEventHandler.class).to(ArtifactRefreshEventHandler.class);
+        bind(EntitiesArtifactsHandler.class).to(EntitiesHandlerImpl.class);
+        bind(VersionedEntitiesArtifactsHandler.class).to(VersionedEntitiesHandlerImpl.class);
+        bind(FileGenerationsArtifactsHandler.class).to(FileGenerationHandlerImpl.class);
 
-        expose(EntityArtifactsProvider.class);
-        expose(VersionedEntityArtifactsProvider.class);
-        expose(ArtifactsRefreshService.class);
-
-        expose(ManageRefreshStatusService.class);
-        expose(RefreshStatusService.class);
-        expose(NotificationEventHandler.class);
-        expose(ArtifactsResource.class);
+        expose(EntitiesArtifactsHandler.class);
+        expose(VersionedEntitiesArtifactsHandler.class);
+        expose(FileGenerationsArtifactsHandler.class);
     }
 
 
     @Provides
-    @Named("artifact-refresh-metrics")
+    @Named("entityHandler")
     @Singleton
-    boolean registerMetrics(PrometheusMetricsHandler metricsHandler)
+    boolean registerEntityHandler(EntitiesArtifactsHandler versionArtifactsHandler)
     {
-        metricsHandler.registerCounter(ArtifactsRefreshServiceImpl.VERSION_REFRESH_COUNTER, ArtifactsRefreshServiceImpl.TOTAL_NUMBER_OF_VERSIONS_REFRESH);
-        metricsHandler.registerHistogram(ArtifactsRefreshServiceImpl.VERSION_REFRESH_DURATION, ArtifactsRefreshServiceImpl.VERSION_REFRESH_DURATION_HELP);
-        return true;
-    }
-
-
-    @Provides
-    @Named("entityRefresh")
-    @Singleton
-    boolean registerEntityRefresh(EntitiesArtifactsHandler versionArtifactsHandler)
-    {
-        ArtifactResolverFactory.registerArtifactHandler(ArtifactType.ENTITIES, versionArtifactsHandler);
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.ENTITIES, versionArtifactsHandler);
         return true;
     }
 
     @Provides
-    @Named("versionedEntityRefresh")
+    @Named("versionedEntityHandler")
     @Singleton
-    boolean registerVersionedEntityRefresh(VersionedEntitiesArtifactsHandler versionedEntitiesArtifactsHandler)
+    boolean registerVersionedEntityHandler(VersionedEntitiesArtifactsHandler versionedEntitiesArtifactsHandler)
     {
-        ArtifactResolverFactory.registerArtifactHandler(ArtifactType.VERSIONED_ENTITIES, versionedEntitiesArtifactsHandler);
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.VERSIONED_ENTITIES, versionedEntitiesArtifactsHandler);
         return true;
     }
 
     @Provides
-    @Named("fileGenerationRefresh")
+    @Named("fileGenerationHandler")
     @Singleton
-    boolean registerFileGenerationRefresh(FileGenerationsArtifactsHandler versionArtifactsHandler)
+    boolean registerFileGenerationHandler(FileGenerationsArtifactsHandler versionArtifactsHandler)
     {
-        ArtifactResolverFactory.registerArtifactHandler(ArtifactType.FILE_GENERATIONS, versionArtifactsHandler);
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.FILE_GENERATIONS, versionArtifactsHandler);
         return true;
     }
 
-
-    @Provides
-    @Singleton
-    @Named("update-versions")
-    boolean initVersions(SchedulesFactory schedulesFactory, ArtifactsRefreshService artifactsRefreshService, ArtifactRepositoryProviderConfiguration configuration)
-    {
-        schedulesFactory.register(UPDATE_VERSIONS_SCHEDULER, LocalDateTime.now().plusSeconds(configuration.getVersionsUpdateIntervalInMillis() / 1000), configuration.getVersionsUpdateIntervalInMillis(), false,() -> artifactsRefreshService.refreshAllVersionsForAllProjects(false,false,UPDATE_VERSIONS_SCHEDULER));
-        return true;
-    }
-
-    @Provides
-    @Singleton
-    @Named("update-revisions")
-    boolean initRevisions(SchedulesFactory schedulesFactory,ArtifactsRefreshService artifactsRefreshService, ArtifactRepositoryProviderConfiguration configuration)
-    {
-        schedulesFactory.register(UPDATE_MASTER_REVISIONS_SCHEDULER, LocalDateTime.now().plusSeconds(configuration.getLatestUpdateIntervalInMillis() / 1000), configuration.getLatestUpdateIntervalInMillis(),false, () -> artifactsRefreshService.refreshMasterSnapshotForAllProjects(false,false,UPDATE_MASTER_REVISIONS_SCHEDULER));
-        return true;
-    }
-
-    @Provides
-    @Singleton
-    @Named("update-missing-versions")
-    boolean initFixVersionsMismatchDaemon(SchedulesFactory schedulesFactory, ArtifactsRefreshService artifactsRefreshService,ArtifactRepositoryProviderConfiguration configuration)
-    {
-        schedulesFactory.register(FIX_MISSING_VERSIONS_SCHEDULE, LocalDateTime.now().plusSeconds(configuration.getVersionsUpdateIntervalInMillis() / 1000), configuration.getFixVersionsMismatchIntervalInMillis(), false,() -> artifactsRefreshService.refreshProjectsWithMissingVersions(false,false,FIX_MISSING_VERSIONS_SCHEDULE));
-        return true;
-    }
 }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/ArtifactsRefreshModule.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/ArtifactsRefreshModule.java
@@ -1,0 +1,101 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.store.artifacts;
+
+import com.google.inject.PrivateModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryProviderConfiguration;
+import org.finos.legend.depot.store.admin.services.schedules.SchedulesFactory;
+import org.finos.legend.depot.store.artifacts.api.ArtifactsRefreshService;
+import org.finos.legend.depot.store.artifacts.api.status.ManageRefreshStatusService;
+import org.finos.legend.depot.store.artifacts.api.status.RefreshStatusService;
+import org.finos.legend.depot.store.artifacts.resources.ArtifactsRefreshResource;
+import org.finos.legend.depot.store.artifacts.services.ArtifactRefreshEventHandler;
+import org.finos.legend.depot.store.artifacts.services.ArtifactsRefreshServiceImpl;
+import org.finos.legend.depot.store.artifacts.store.mongo.ArtifactsMongo;
+import org.finos.legend.depot.store.artifacts.store.mongo.MongoRefreshStatus;
+import org.finos.legend.depot.store.artifacts.store.mongo.api.UpdateArtifacts;
+import org.finos.legend.depot.store.notifications.api.NotificationEventHandler;
+import org.finos.legend.depot.tracing.api.PrometheusMetricsHandler;
+
+import javax.inject.Named;
+import java.time.LocalDateTime;
+
+public class ArtifactsRefreshModule extends PrivateModule
+{
+    private static final String UPDATE_MASTER_REVISIONS_SCHEDULER = "refreshVersionArtifacts-master-revisions-scheduler";
+    private static final String UPDATE_VERSIONS_SCHEDULER = "refreshVersionArtifacts-versions-scheduler";
+    private static final String FIX_MISSING_VERSIONS_SCHEDULE = "fix-missing-versions-schedule";
+
+    @Override
+    protected void configure()
+    {
+        bind(ArtifactsRefreshResource.class);
+
+        bind(UpdateArtifacts.class).to(ArtifactsMongo.class);
+        bind(ManageRefreshStatusService.class).to(MongoRefreshStatus.class);
+        bind(RefreshStatusService.class).to(MongoRefreshStatus.class);
+
+        bind(ArtifactsRefreshService.class).to(ArtifactsRefreshServiceImpl.class);
+        bind(NotificationEventHandler.class).to(ArtifactRefreshEventHandler.class);
+
+        expose(ArtifactsRefreshService.class);
+        expose(ManageRefreshStatusService.class);
+        expose(RefreshStatusService.class);
+        expose(NotificationEventHandler.class);
+        expose(ArtifactsRefreshResource.class);
+    }
+
+
+    @Provides
+    @Named("artifact-refresh-metrics")
+    @Singleton
+    boolean registerMetrics(PrometheusMetricsHandler metricsHandler)
+    {
+        metricsHandler.registerCounter(ArtifactsRefreshServiceImpl.VERSION_REFRESH_COUNTER, ArtifactsRefreshServiceImpl.TOTAL_NUMBER_OF_VERSIONS_REFRESH);
+        metricsHandler.registerHistogram(ArtifactsRefreshServiceImpl.VERSION_REFRESH_DURATION, ArtifactsRefreshServiceImpl.VERSION_REFRESH_DURATION_HELP);
+        return true;
+    }
+
+
+    @Provides
+    @Singleton
+    @Named("update-versions")
+    boolean initVersions(SchedulesFactory schedulesFactory, ArtifactsRefreshService artifactsRefreshService, ArtifactRepositoryProviderConfiguration configuration)
+    {
+        schedulesFactory.register(UPDATE_VERSIONS_SCHEDULER, LocalDateTime.now().plusSeconds(configuration.getVersionsUpdateIntervalInMillis() / 1000), configuration.getVersionsUpdateIntervalInMillis(), false,() -> artifactsRefreshService.refreshAllVersionsForAllProjects(false,false,UPDATE_VERSIONS_SCHEDULER));
+        return true;
+    }
+
+    @Provides
+    @Singleton
+    @Named("update-revisions")
+    boolean initRevisions(SchedulesFactory schedulesFactory,ArtifactsRefreshService artifactsRefreshService, ArtifactRepositoryProviderConfiguration configuration)
+    {
+        schedulesFactory.register(UPDATE_MASTER_REVISIONS_SCHEDULER, LocalDateTime.now().plusSeconds(configuration.getLatestUpdateIntervalInMillis() / 1000), configuration.getLatestUpdateIntervalInMillis(),false, () -> artifactsRefreshService.refreshMasterSnapshotForAllProjects(false,false,UPDATE_MASTER_REVISIONS_SCHEDULER));
+        return true;
+    }
+
+    @Provides
+    @Singleton
+    @Named("update-missing-versions")
+    boolean initFixVersionsMismatchDaemon(SchedulesFactory schedulesFactory, ArtifactsRefreshService artifactsRefreshService,ArtifactRepositoryProviderConfiguration configuration)
+    {
+        schedulesFactory.register(FIX_MISSING_VERSIONS_SCHEDULE, LocalDateTime.now().plusSeconds(configuration.getVersionsUpdateIntervalInMillis() / 1000), configuration.getFixVersionsMismatchIntervalInMillis(), false,() -> artifactsRefreshService.refreshProjectsWithMissingVersions(false,false,FIX_MISSING_VERSIONS_SCHEDULE));
+        return true;
+    }
+}

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/ArtifactsRefreshService.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/ArtifactsRefreshService.java
@@ -36,11 +36,5 @@ public interface ArtifactsRefreshService
 
     MetadataEventResponse refreshProjectsWithMissingVersions(boolean fullUpdate,boolean transitive, String parentEventId);
 
-    MetadataEventResponse retireLeastRecentlyUsedVersions(int numberOfDays);
-
-    MetadataEventResponse retireOldProjectVersions(int versionsToKeep);
-
-    void delete(String groupId, String artifactId, String versionId);
-
     boolean createIndexesIfAbsent();
   }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/resources/ArtifactsRefreshResource.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/resources/ArtifactsRefreshResource.java
@@ -46,20 +46,20 @@ import java.util.List;
 
 
 @Path("")
-@Api("Artifacts")
-public class ArtifactsResource extends BaseAuthorisedResource
+@Api("Artifacts Refresh")
+public class ArtifactsRefreshResource extends BaseAuthorisedResource
 {
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-    public static final String ARTIFACTS_RESOURCE = "Artifacts";
+    public static final String ARTIFACTS_RESOURCE = "ArtifactsRefresh";
     private final ArtifactsRefreshService artifactsRefreshService;
     private final ManageRefreshStatusService refreshStatusService;
 
 
     @Inject
-    public ArtifactsResource(ArtifactsRefreshService artifactsRefreshService,
-                             ManageRefreshStatusService updateStatusService,
-                             AuthorisationProvider authorisationProvider,
-                             @Named("requestPrincipal") Provider<Principal> principalProvider)
+    public ArtifactsRefreshResource(ArtifactsRefreshService artifactsRefreshService,
+                                    ManageRefreshStatusService updateStatusService,
+                                    AuthorisationProvider authorisationProvider,
+                                    @Named("requestPrincipal") Provider<Principal> principalProvider)
     {
         super(authorisationProvider, principalProvider);
         this.artifactsRefreshService = artifactsRefreshService;
@@ -162,30 +162,13 @@ public class ArtifactsResource extends BaseAuthorisedResource
     @Path("/artifactsRefresh/latest")
     @ApiOperation(ResourceLoggingAndTracing.UPDATE_ALL_MASTER_REVISIONS)
     @Produces(MediaType.APPLICATION_JSON)
-    public MetadataEventResponse refreshAllProjectsAllLatestRevisions(@QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh of processed jar files, versions ,etc") boolean fullUpdate,
-                                                            @QueryParam("transitive") @DefaultValue("false") @ApiParam("Whether to refresh its dependencies") boolean transitive)
+    public MetadataEventResponse updateAllProjectsAllLatestRevisions(@QueryParam("fullUpdate") @DefaultValue("false") @ApiParam("Whether to force refresh of processed jar files, versions ,etc") boolean fullUpdate,
+                                                                     @QueryParam("transitive") @DefaultValue("false") @ApiParam("Whether to refresh its dependencies") boolean transitive)
     {
         return handle(ResourceLoggingAndTracing.UPDATE_ALL_MASTER_REVISIONS, () ->
         {
             validateUser();
             return artifactsRefreshService.refreshMasterSnapshotForAllProjects(fullUpdate,transitive,ResourceLoggingAndTracing.UPDATE_ALL_MASTER_REVISIONS);
-        });
-    }
-
-    @DELETE
-    @Path("/artifactDelete/{groupId}/{artifactId}/versions/{versionId}")
-    @ApiOperation(ResourceLoggingAndTracing.DELETE_VERSION)
-    @Produces(MediaType.APPLICATION_JSON)
-    public MetadataEventResponse purgeVersion(@PathParam("groupId") String groupId,
-                                              @PathParam("artifactId") String artifactId,
-                                              @PathParam("versionId") String versionId)
-    {
-
-        return handle(ResourceLoggingAndTracing.PURGE_ALL_VERSIONS, () ->
-        {
-            validateUser();
-            artifactsRefreshService.delete(groupId, artifactId, versionId);
-            return new MetadataEventResponse();
         });
     }
 

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/services/ArtifactHandlerFactory.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/services/ArtifactHandlerFactory.java
@@ -20,14 +20,15 @@ import org.finos.legend.depot.store.artifacts.api.ProjectArtifactsHandler;
 
 import javax.inject.Singleton;
 import java.util.EnumMap;
+import java.util.Set;
 
 @Singleton
-public class ArtifactResolverFactory
+public class ArtifactHandlerFactory
 {
-    private static final ArtifactResolverFactory instance = new ArtifactResolverFactory();
+    private static final ArtifactHandlerFactory instance = new ArtifactHandlerFactory();
     private final EnumMap<ArtifactType, ProjectArtifactsHandler> artifactHandlers = new EnumMap<>(ArtifactType.class);
 
-    private ArtifactResolverFactory()
+    private ArtifactHandlerFactory()
     {
     }
 
@@ -39,5 +40,10 @@ public class ArtifactResolverFactory
     public static ProjectArtifactsHandler getArtifactHandler(ArtifactType artifactType)
     {
         return instance.artifactHandlers.get(artifactType);
+    }
+
+    public static Set<ArtifactType> getSupportedTypes()
+    {
+        return instance.artifactHandlers.keySet();
     }
 }

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceExceptionEscenarios.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceExceptionEscenarios.java
@@ -95,9 +95,9 @@ public class TestArtifactsRefreshServiceExceptionEscenarios extends TestStoreMon
     @Before
     public void setUpData() throws ArtifactRepositoryException
     {
-        ArtifactResolverFactory.registerArtifactHandler(ArtifactType.ENTITIES, new EntitiesHandlerImpl(entitiesService, entitiesProvider));
-        ArtifactResolverFactory.registerArtifactHandler(ArtifactType.VERSIONED_ENTITIES, new EntitiesHandlerImpl(entitiesService, versionedEntityProvider));
-        ArtifactResolverFactory.registerArtifactHandler(ArtifactType.FILE_GENERATIONS, new FileGenerationHandlerImpl(repository, fileGenerationsProvider, new FileGenerationsServiceImpl(mongoGenerations, mongoEntities, projectsService)));
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.ENTITIES, new EntitiesHandlerImpl(entitiesService, entitiesProvider));
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.VERSIONED_ENTITIES, new EntitiesHandlerImpl(entitiesService, versionedEntityProvider));
+        ArtifactHandlerFactory.registerArtifactHandler(ArtifactType.FILE_GENERATIONS, new FileGenerationHandlerImpl(repository, fileGenerationsProvider, new FileGenerationsServiceImpl(mongoGenerations, mongoEntities, projectsService)));
 
         List<ProjectData> projects = Arrays.asList(new ProjectData(PROJECT_B, TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID),
                                                    new ProjectData(PROJECT_A, TEST_GROUP_ID, TEST_ARTIFACT_ID),

--- a/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/domain/VersionMismatch.java
+++ b/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/domain/VersionMismatch.java
@@ -35,9 +35,9 @@ public class VersionMismatch
     @JsonProperty
     public String artifactId;
     @JsonProperty
-    public List<String> versionsNotInCache = new ArrayList<>();
+    public List<String> versionsNotInStore = new ArrayList<>();
     @JsonProperty
-    public List<String> versionsNotInRepo = new ArrayList<>();
+    public List<String> versionsNotInRepository = new ArrayList<>();
     @JsonProperty
     @EqualsExclude
     public List<String> errors = new ArrayList<>();
@@ -48,8 +48,8 @@ public class VersionMismatch
         this.projectId = projectId;
         this.groupId = groupId;
         this.artifactId = artifactId;
-        this.versionsNotInCache.addAll(versionsNotInCache);
-        this.versionsNotInRepo.addAll(versionsNotInRepo);
+        this.versionsNotInStore.addAll(versionsNotInCache);
+        this.versionsNotInRepository.addAll(versionsNotInRepo);
         this.errors.addAll(errors);
     }
 

--- a/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/services/RepositoryServices.java
+++ b/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/services/RepositoryServices.java
@@ -83,11 +83,11 @@ public class RepositoryServices
                         PrometheusMetricsFactory.getInstance().increaseGauge(MISSING_REPO_VERSIONS,versionsNotInCache.size());
                         PrometheusMetricsFactory.getInstance().increaseGauge(MISSING_STORE_VERSIONS,versionsNotInRepo.size());
                         versionMismatches.add(new VersionMismatch(p.getProjectId(), p.getGroupId(), p.getArtifactId(), versionsNotInCache, versionsNotInRepo));
-                        LOGGER.info("version-mismatch found for {} {} {} : notInCache [{}], notInRepo [{}]", p.getProjectId(), p.getGroupId(), p.getArtifactId(), versionsNotInCache, versionsNotInRepo);
+                        LOGGER.info("version-mismatch found for {} {} {} : notInStore[{}], notInRepository [{}]", p.getProjectId(), p.getGroupId(), p.getArtifactId(), versionsNotInCache, versionsNotInRepo);
                     }
 
             }
-            catch (ArtifactRepositoryException e)
+            catch (Exception e)
             {
                 String message = String.format("Could not get versions for %s:%s exception: %s ",p.getGroupId(),p.getArtifactId(),e.getMessage());
                 LOGGER.error(message);

--- a/legend-depot-artifacts-repository-api/src/test/java/org/finos/legend/depot/artifacts/repository/services/TestVersionsMismatch.java
+++ b/legend-depot-artifacts-repository-api/src/test/java/org/finos/legend/depot/artifacts/repository/services/TestVersionsMismatch.java
@@ -18,7 +18,6 @@ package org.finos.legend.depot.artifacts.repository.services;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryException;
 import org.finos.legend.depot.domain.project.ProjectData;
-import org.finos.legend.depot.services.api.projects.ManageProjectsService;
 import org.finos.legend.depot.artifacts.repository.domain.VersionMismatch;
 import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
@@ -71,13 +70,13 @@ public class TestVersionsMismatch
         Assert.assertEquals(1, counts.stream().filter(p -> p.projectId.equals("PROD-C")).count());
 
         VersionMismatch prodA = counts.stream().filter(p -> p.projectId.equals("PROD-A")).findFirst().get();
-        Assert.assertEquals(1, prodA.versionsNotInCache.size());
-        Assert.assertEquals("2.3.1", prodA.versionsNotInCache.get(0));
+        Assert.assertEquals(1, prodA.versionsNotInStore.size());
+        Assert.assertEquals("2.3.1", prodA.versionsNotInStore.get(0));
         VersionMismatch prodB = counts.stream().filter(p -> p.projectId.equals("PROD-B")).findFirst().get();
-        Assert.assertEquals("1.0.1", prodB.versionsNotInCache.get(0));
-        Assert.assertEquals("1.0.0", prodB.versionsNotInRepo.get(0));
+        Assert.assertEquals("1.0.1", prodB.versionsNotInStore.get(0));
+        Assert.assertEquals("1.0.0", prodB.versionsNotInRepository.get(0));
         VersionMismatch prodC = counts.stream().filter(p -> p.projectId.equals("PROD-C")).findFirst().get();
-        Assert.assertEquals("2.0.1", prodC.versionsNotInRepo.get(0));
+        Assert.assertEquals("2.0.1", prodC.versionsNotInRepository.get(0));
 
 
     }

--- a/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/tracing/resources/ResourceLoggingAndTracing.java
+++ b/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/tracing/resources/ResourceLoggingAndTracing.java
@@ -44,8 +44,8 @@ public class ResourceLoggingAndTracing
     public static final String UPDATE_ALL_VERSIONS = "refresh all versions";
     public static final String UPDATE_VERSION = "refresh version";
     public static final String UPDATE_ALL_PROJECT_VERSIONS = "refresh all project versions";
-    public static final String PURGE_ALL_VERSIONS = "purge old versions";
-    public static final String DELETE_VERSION = "delete project version";
+    public static final String PURGE_OLD_VERSIONS = "purge old versions";
+    public static final String PURGE_VERSION = "purge version";
     public static final String GET_REVISION_FILE_GENERATION_ENTITIES = "get revision generation entities";
     public static final String GET_VERSION_FILE_GENERATION_ENTITIES = "get version generation entities";
     public static final String GET_REVISION_FILE_GENERATION = "get revision file generations";

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/generation/file/TestFileGenerationsStore.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/generation/file/TestFileGenerationsStore.java
@@ -15,11 +15,6 @@
 
 package org.finos.legend.depot.store.mongo.generation.file;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.client.MongoCollection;
-import org.bson.Document;
 import org.finos.legend.depot.domain.generation.file.StoredFileGeneration;
 import org.finos.legend.depot.store.api.generation.file.UpdateFileGenerations;
 import org.finos.legend.depot.store.mongo.TestStoreMongo;
@@ -27,8 +22,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.InputStream;
-import java.net.URL;
 import java.util.List;
 
 import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
@@ -39,55 +32,6 @@ public class TestFileGenerationsStore extends TestStoreMongo
     private UpdateFileGenerations generations = new FileGenerationsMongo(mongoProvider);
     private static String TEST_GROUP_ID = "examples.metadata";
     private static String TEST_ARTIFACT_ID = "test";
-
-
-    private List<StoredFileGeneration> readGenerationsFile(URL fileName)
-    {
-        try
-        {
-            InputStream stream = fileName.openStream();
-            String jsonInput = new java.util.Scanner(stream).useDelimiter("\\A").next();
-
-            List<StoredFileGeneration> generations = new ObjectMapper().readValue(jsonInput, new TypeReference<List<StoredFileGeneration>>()
-            {
-            });
-            Assert.assertNotNull("testing file" + fileName.getFile(), generations);
-            return generations;
-        }
-        catch (Exception e)
-        {
-            Assert.fail("an error has occurred loading test metadata" + e.getMessage());
-        }
-        return null;
-    }
-
-    private void setUpFileGenerationFromFile(URL generationsData)
-    {
-        try
-        {
-            readGenerationsFile(generationsData).forEach(project ->
-            {
-                try
-                {
-                    getMongoFileGnerations().insertOne(Document.parse(new ObjectMapper().writeValueAsString(project)));
-                }
-                catch (JsonProcessingException e)
-                {
-                    Assert.fail("an error has occurred loading test project metadata" + e.getMessage());
-                }
-            });
-            Assert.assertNotNull(getMongoFileGnerations());
-        }
-        catch (Exception e)
-        {
-            Assert.fail("an error has occurred loading test project metadata" + e.getMessage());
-        }
-    }
-
-    private MongoCollection getMongoFileGnerations()
-    {
-        return getMongoDatabase().getCollection(FileGenerationsMongo.COLLECTION);
-    }
 
 
     @Before

--- a/legend-depot-store-server/pom.xml
+++ b/legend-depot-store-server/pom.xml
@@ -59,6 +59,10 @@
             <groupId>org.finos.legend.depot</groupId>
             <artifactId>legend-depot-artifacts-refresh</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-artifacts-purge</artifactId>
+        </dependency>
         <!-- DEPOT -->
 
         <!-- SHARED -->

--- a/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/server/LegendDepotStoreServer.java
+++ b/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/server/LegendDepotStoreServer.java
@@ -28,6 +28,8 @@ import org.finos.legend.depot.core.http.resources.InfoPageModule;
 import org.finos.legend.depot.services.AdminServicesModule;
 import org.finos.legend.depot.store.admin.StoreAdminModule;
 import org.finos.legend.depot.store.artifacts.ArtifactsModule;
+import org.finos.legend.depot.store.artifacts.ArtifactsRefreshModule;
+import org.finos.legend.depot.store.artifacts.purge.ArtifactsPurgeModule;
 import org.finos.legend.depot.store.guice.DepotStoreResourcesModule;
 import org.finos.legend.depot.store.guice.DepotStoreServerModule;
 import org.finos.legend.depot.store.metrics.MetricsModule;
@@ -79,6 +81,8 @@ public class LegendDepotStoreServer extends BaseServer<DepotStoreServerConfigura
                 new DepotStoreResourcesModule(),
                 new StoreStatusModule(),
                 new ArtifactsModule(),
+                new ArtifactsRefreshModule(),
+                new ArtifactsPurgeModule(),
                 new RepositoryModule(),
                 new TracingModule(),
                 new MetricsModule(),

--- a/legend-depot-store-server/src/main/resources/authorisedIdentities.json
+++ b/legend-depot-store-server/src/main/resources/authorisedIdentities.json
@@ -1,5 +1,7 @@
 {
-  "Artifacts": [
+  "ArtifactsPurge": [
+  ],
+  "ArtifactsRefresh": [
   ],
   "Store Administration": [
   ],

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <module>legend-depot-core-authorisation</module>
 
         <module>legend-depot-artifacts-refresh</module>
+        <module>legend-depot-artifacts-purge</module>
         <module>legend-depot-artifacts-repository-api</module>
         <module>legend-depot-artifacts-repository-maven-impl</module>
 
@@ -434,6 +435,11 @@
             <dependency>
                 <groupId>org.finos.legend.depot</groupId>
                 <artifactId>legend-depot-artifacts-refresh</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.finos.legend.depot</groupId>
+                <artifactId>legend-depot-artifacts-purge</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
- separated artifacts refresh functionality from purge
- purge old versions has been moved to the new purge module and exposed in the resource
- purge can only invoked manually for now