### PR TITLE
unexclude com.nimbusds.lang-tag to avoid ClassNotFound exception when using Pac4j with Gitlab

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,10 +565,6 @@
                 <scope>runtime</scope>
                 <exclusions>
                     <exclusion>
-                        <groupId>com.nimbusds</groupId>
-                        <artifactId>lang-tag</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>javax.activation</groupId>
                         <artifactId>activation</artifactId>
                     </exclusion>


### PR DESCRIPTION
If one starts depot-store/depot server right now with client of type `org.finos.legend.server.pac4j.gitlab.GitlabClient`, one would see `ClassNotFoundException` for the class `LangTagException` which can be found in `com.nimbusds.lang-tag`, we might have accidentally excluded this.