### PR TITLE
minor API swagger fix

### DIFF
--- a/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/resources/NotificationsManagerResource.java
+++ b/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/resources/NotificationsManagerResource.java
@@ -137,6 +137,7 @@ public class NotificationsManagerResource extends BaseAuthorisedResource
     @GET
     @Path("/queue/{projectId}/{groupId}/{artifactId}/{versionId}")
     @ApiOperation(ResourceLoggingAndTracing.ENQUEUE_EVENT)
+    @Produces(MediaType.TEXT_PLAIN)
     public String queueEvent(@PathParam("projectId") String projectId,
                              @PathParam("groupId") String groupId,
                              @PathParam("artifactId") String artifactId,


### PR DESCRIPTION
Currently, Swagger assumes the API for `/queue` returns a JSON, but in fact, it returns a string, this is the correction for that.