### PR TITLE
configure persist metrics schedule to be delayed to avoid concurrency errors

### DIFF
--- a/legend-depot-store-metrics/src/main/java/org/finos/legend/depot/store/metrics/MetricsModule.java
+++ b/legend-depot-store-metrics/src/main/java/org/finos/legend/depot/store/metrics/MetricsModule.java
@@ -39,7 +39,7 @@ public class MetricsModule extends PrivateModule
     @Named("persist-metrics")
     boolean scheduleMetricsPersistence(SchedulesFactory schedulesFactory, QueryMetricsHandler queryMetrics)
     {
-        schedulesFactory.register("persist-metrics", LocalDateTime.now().plusMinutes(1), 5 * 60000L, true, () ->
+        schedulesFactory.register("persist-metrics", LocalDateTime.now().plusMinutes(1), 20160 * 60000L, true, () ->
         {
             queryMetrics.persistMetrics();
             return true;


### PR DESCRIPTION
configure persist metrics schedule to be delayed to avoid concurrency errors