### PR TITLE
more robust process interruptions/operational enhancements

### DIFF
--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/ParentEvent.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/api/ParentEvent.java
@@ -1,0 +1,35 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.store.artifacts.api;
+
+public enum ParentEvent
+{
+    UPDATE_PROJECT_VERSION,
+    UPDATE_PROJECT_HEAD,
+    UPDATE_PROJECT_ALL_VERSIONS,
+    UPDATE_ALL_PROJECT_ALL_VERSIONS,
+    UPDATE_ALL_PROJECT_HEAD,
+    FIX_MISSING_VERSIONS,
+    REFRESH_ALL_VERSION_ARTIFACTS_SCHEDULE,
+    FIX_MISSING_VERSIONS_SCHEDULE;
+
+    private static final String SEPARATOR = "_";
+
+    public static String build(String groupId, String artifactId, String versionId,String parentEventId)
+    {
+        return parentEventId != null ? parentEventId : groupId + SEPARATOR + artifactId + SEPARATOR + versionId;
+    }
+}

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/resources/ArtifactRefreshStatusResource.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/resources/ArtifactRefreshStatusResource.java
@@ -22,23 +22,18 @@ import org.finos.legend.depot.core.authorisation.api.AuthorisationProvider;
 import org.finos.legend.depot.core.authorisation.resources.BaseAuthorisedResource;
 import org.finos.legend.depot.store.admin.api.artifacts.RefreshStatusStore;
 import org.finos.legend.depot.store.admin.domain.artifacts.RefreshStatus;
+import org.finos.legend.depot.store.artifacts.api.ParentEvent;
 import org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.security.Principal;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.finos.legend.depot.store.artifacts.resources.ArtifactsRefreshResource.ARTIFACTS_RESOURCE;
@@ -47,7 +42,6 @@ import static org.finos.legend.depot.store.artifacts.resources.ArtifactsRefreshR
 @Api("Artifacts Refresh")
 public class ArtifactRefreshStatusResource extends BaseAuthorisedResource
 {
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private final RefreshStatusStore refreshStatusService;
 
     @Override
@@ -69,38 +63,14 @@ public class ArtifactRefreshStatusResource extends BaseAuthorisedResource
     @Path("/artifactsRefresh/status")
     @ApiOperation("refresh status")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<RefreshStatus> getStatus(
+    public List<RefreshStatus> getRunningVersionsRefresh(
             @QueryParam("groupId") String group,
             @QueryParam("artifactId") String artifact,
-            @QueryParam("versionId") String version,
+            @QueryParam("versionId") @ApiParam("x.y.z/master-SNAPSHOT") String version,
             @QueryParam("eventId") String eventId,
-            @QueryParam("parentEventId")
-            @ApiParam("refresh could be started by another event, eg refresh all cache versions") String parentId,
-            @QueryParam("running") Boolean running,
-            @QueryParam("success") Boolean success,
-            @QueryParam("startTimeFrom")
-            @ApiParam("entries that started refresh from this date yyyy-MM-dd HH:mm:ss") String startTimeFrom,
-            @QueryParam("startTimeTo")
-            @ApiParam("entries that started refresh to this date yyyy-MM-dd HH:mm:ss (default is now)") String startTimeTo
+            @QueryParam("parentEventId") @ApiParam("refresh could be started by another event") ParentEvent parentId
     )
     {
-        LocalDateTime fromStatTime = startTimeFrom == null ? null : LocalDateTime.parse(startTimeFrom, DATE_TIME_FORMATTER);
-        LocalDateTime toStartTime = startTimeTo == null ? LocalDateTime.now() : LocalDateTime.parse(startTimeTo, DATE_TIME_FORMATTER);
-        return handle(ResourceLoggingAndTracing.STORE_STATUS, () -> refreshStatusService.find(group, artifact, version,eventId,parentId,running, success, fromStatTime,toStartTime));
-    }
-
-    @DELETE
-    @Path("/artifactsRefreshStatus/{id}")
-    @ApiOperation("delete by id")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response resetStatus(@PathParam("id") String id
-    )
-    {
-        return handle(ResourceLoggingAndTracing.TOGGLE_STORE_STATUS, () ->
-        {
-            validateUser();
-            refreshStatusService.delete(id);
-            return Response.status(Response.Status.NO_CONTENT).build();
-        });
+        return handle(ResourceLoggingAndTracing.STORE_STATUS, () -> refreshStatusService.find(group, artifact, version,eventId,parentId != null ? parentId.name() : null));
     }
 }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/resources/ArtifactsRefreshResource.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/resources/ArtifactsRefreshResource.java
@@ -22,7 +22,7 @@ import org.finos.legend.depot.core.authorisation.api.AuthorisationProvider;
 import org.finos.legend.depot.core.authorisation.resources.BaseAuthorisedResource;
 import org.finos.legend.depot.domain.api.MetadataEventResponse;
 import org.finos.legend.depot.store.artifacts.api.ArtifactsRefreshService;
-import org.finos.legend.depot.store.artifacts.api.ParentEventBuilder;
+import org.finos.legend.depot.store.artifacts.api.ParentEvent;
 import org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing;
 
 import javax.inject.Inject;
@@ -69,7 +69,7 @@ public class ArtifactsRefreshResource extends BaseAuthorisedResource
     {
         validateUser();
         return handle(ResourceLoggingAndTracing.UPDATE_VERSION, ResourceLoggingAndTracing.UPDATE_VERSION + groupId + artifactId + versionId,
-                () -> artifactsRefreshService.refreshVersionForProject(groupId, artifactId,versionId,transitive,ParentEventBuilder.build(groupId,artifactId,versionId, ResourceLoggingAndTracing.UPDATE_VERSION)));
+                () -> artifactsRefreshService.refreshVersionForProject(groupId, artifactId,versionId,transitive, ParentEvent.build(groupId,artifactId,versionId, ParentEvent.UPDATE_PROJECT_VERSION.name())));
     }
 
     @PUT
@@ -83,7 +83,7 @@ public class ArtifactsRefreshResource extends BaseAuthorisedResource
     {
         validateUser();
         return handle(ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION, ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION + groupId + artifactId,
-                () -> artifactsRefreshService.refreshMasterSnapshotForProject(groupId,artifactId,fullUpdate,transitive, ParentEventBuilder.build(groupId,artifactId,MASTER_SNAPSHOT, ResourceLoggingAndTracing.UPDATE_LATEST_PROJECT_REVISION)));
+                () -> artifactsRefreshService.refreshMasterSnapshotForProject(groupId,artifactId,fullUpdate,transitive, ParentEvent.build(groupId,artifactId,MASTER_SNAPSHOT, ParentEvent.UPDATE_PROJECT_HEAD.name())));
     }
 
     @PUT
@@ -98,7 +98,7 @@ public class ArtifactsRefreshResource extends BaseAuthorisedResource
     {
         validateUser();
         return handle(ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS, ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS + groupId + artifactId,
-                () -> artifactsRefreshService.refreshAllVersionsForProject(groupId, artifactId, fullUpdate,allVersions,transitive,ParentEventBuilder.build(groupId,artifactId,"ALL", ResourceLoggingAndTracing.UPDATE_ALL_PROJECT_VERSIONS)));
+                () -> artifactsRefreshService.refreshAllVersionsForProject(groupId, artifactId, fullUpdate,allVersions,transitive, ParentEvent.build(groupId,artifactId,"ALL", ParentEvent.UPDATE_PROJECT_ALL_VERSIONS.name())));
     }
 
 
@@ -113,7 +113,7 @@ public class ArtifactsRefreshResource extends BaseAuthorisedResource
         return handle(ResourceLoggingAndTracing.UPDATE_ALL_VERSIONS, () ->
         {
             validateUser();
-            return artifactsRefreshService.refreshAllVersionsForAllProjects(fullUpdate,allVersions,transitive,ResourceLoggingAndTracing.UPDATE_ALL_VERSIONS);
+            return artifactsRefreshService.refreshAllVersionsForAllProjects(fullUpdate,allVersions,transitive, ParentEvent.UPDATE_ALL_PROJECT_ALL_VERSIONS.name());
         });
     }
 
@@ -127,7 +127,7 @@ public class ArtifactsRefreshResource extends BaseAuthorisedResource
         return handle(ResourceLoggingAndTracing.UPDATE_ALL_MASTER_REVISIONS, () ->
         {
             validateUser();
-            return artifactsRefreshService.refreshMasterSnapshotForAllProjects(fullUpdate,transitive,ResourceLoggingAndTracing.UPDATE_ALL_MASTER_REVISIONS);
+            return artifactsRefreshService.refreshMasterSnapshotForAllProjects(fullUpdate,transitive, ParentEvent.UPDATE_ALL_PROJECT_HEAD.name());
         });
     }
 
@@ -147,7 +147,7 @@ public class ArtifactsRefreshResource extends BaseAuthorisedResource
         return handle(ResourceLoggingAndTracing.FIX_MISSING_VERSIONS, () ->
         {
             validateUser();
-            return this.artifactsRefreshService.refreshProjectsWithMissingVersions(ResourceLoggingAndTracing.FIX_MISSING_VERSIONS);
+            return this.artifactsRefreshService.refreshProjectsWithMissingVersions(ParentEvent.FIX_MISSING_VERSIONS.name());
         });
     }
 }

--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/services/ArtifactsRefreshServiceImpl.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/services/ArtifactsRefreshServiceImpl.java
@@ -24,7 +24,7 @@ import org.finos.legend.depot.domain.notifications.MetadataNotification;
 import org.finos.legend.depot.domain.project.StoreProjectData;
 import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.depot.store.artifacts.api.ArtifactsRefreshService;
-import org.finos.legend.depot.store.artifacts.api.ParentEventBuilder;
+import org.finos.legend.depot.store.artifacts.api.ParentEvent;
 import org.finos.legend.depot.store.notifications.api.Queue;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.slf4j.Logger;
@@ -70,7 +70,7 @@ public class ArtifactsRefreshServiceImpl implements ArtifactsRefreshService
     @Override
     public MetadataEventResponse  refreshAllVersionsForAllProjects(boolean fullUpdate,boolean allVersions,boolean transitive,String parentEventId)
     {
-        String parentEvent = ParentEventBuilder.build(ALL, ALL, ALL,parentEventId);
+        String parentEvent = ParentEvent.build(ALL, ALL, ALL,parentEventId);
         MetadataNotification allVersionAllProjects = new MetadataNotification(ALL,ALL,ALL,ALL,fullUpdate,transitive,parentEvent);
         return versionRefreshHandler.executeWithTrace(REFRESH_ALL_VERSIONS_FOR_ALL_PROJECTS,allVersionAllProjects, () ->
                 {
@@ -87,7 +87,7 @@ public class ArtifactsRefreshServiceImpl implements ArtifactsRefreshService
     @Override
     public MetadataEventResponse refreshMasterSnapshotForAllProjects(boolean fullUpdate, boolean transitive, String parentEventId)
     {
-        String parentEvent = ParentEventBuilder.build(ALL, ALL, MASTER_SNAPSHOT,parentEventId);
+        String parentEvent = ParentEvent.build(ALL, ALL, MASTER_SNAPSHOT,parentEventId);
         MetadataNotification masterSnapshotAllProjects = new MetadataNotification(ALL,ALL,ALL,MASTER_SNAPSHOT,fullUpdate,transitive,parentEvent);
         return versionRefreshHandler.executeWithTrace(REFRESH_MASTER_SNAPSHOT_FOR_ALL_PROJECTS,masterSnapshotAllProjects, () ->
                 {
@@ -104,7 +104,7 @@ public class ArtifactsRefreshServiceImpl implements ArtifactsRefreshService
     @Override
     public MetadataEventResponse refreshAllVersionsForProject(String groupId, String artifactId, boolean fullUpdate,boolean allVersions,boolean transitive,String parentEventId)
     {
-        String parentEvent = ParentEventBuilder.build(groupId, artifactId, ALL, parentEventId);
+        String parentEvent = ParentEvent.build(groupId, artifactId, ALL, parentEventId);
         StoreProjectData projectData = getProject(groupId, artifactId);
         MetadataNotification allVersionForProject = new MetadataNotification(projectData.getProjectId(),groupId,artifactId,ALL,fullUpdate,transitive,parentEvent);
         return versionRefreshHandler.executeWithTrace(REFRESH_ALL_VERSIONS_FOR_PROJECT, allVersionForProject, () ->
@@ -122,7 +122,7 @@ public class ArtifactsRefreshServiceImpl implements ArtifactsRefreshService
     @Override
     public MetadataEventResponse refreshMasterSnapshotForProject(String groupId, String artifactId, boolean fullUpdate, boolean transitive, String parentEventId)
     {
-        String parentEvent = ParentEventBuilder.build(groupId, artifactId, MASTER_SNAPSHOT, parentEventId);
+        String parentEvent = ParentEvent.build(groupId, artifactId, MASTER_SNAPSHOT, parentEventId);
         StoreProjectData projectData = getProject(groupId, artifactId);
         MetadataNotification masterSnapshotForProject = new MetadataNotification(projectData.getProjectId(), groupId, artifactId, MASTER_SNAPSHOT, fullUpdate, transitive, parentEvent);
         return versionRefreshHandler.executeWithTrace(REFRESH_MASTER_SNAPSHOT_FOR_PROJECT, masterSnapshotForProject, () ->
@@ -139,7 +139,7 @@ public class ArtifactsRefreshServiceImpl implements ArtifactsRefreshService
     @Override
     public MetadataEventResponse refreshVersionForProject(String groupId, String artifactId, String versionId, boolean transitive,String parentEventId)
     {
-        String parentEvent = ParentEventBuilder.build(groupId, artifactId, versionId, parentEventId);
+        String parentEvent = ParentEvent.build(groupId, artifactId, versionId, parentEventId);
         StoreProjectData projectData = getProject(groupId, artifactId);
         MetadataNotification versionForProject = new MetadataNotification(projectData.getProjectId(),groupId,artifactId,versionId,true,transitive,parentEvent);
         return versionRefreshHandler.executeWithTrace(REFRESH_PROJECT_VERSION_ARTIFACTS, versionForProject, () ->
@@ -156,7 +156,7 @@ public class ArtifactsRefreshServiceImpl implements ArtifactsRefreshService
     @Override
     public MetadataEventResponse refreshProjectsWithMissingVersions(String parentEventId)
     {
-        String parentEvent = ParentEventBuilder.build(ALL, ALL,MISSING,parentEventId);
+        String parentEvent = ParentEvent.build(ALL, ALL,MISSING,parentEventId);
         MetadataNotification missingVersions = new MetadataNotification(ALL,ALL,ALL,MISSING,true,false,parentEvent);
         return versionRefreshHandler.executeWithTrace(REFRESH_PROJECTS_WITH_MISSING_VERSIONS,missingVersions, () ->
         {
@@ -198,7 +198,7 @@ public class ArtifactsRefreshServiceImpl implements ArtifactsRefreshService
 
     private MetadataEventResponse refreshAllVersionsForProject(StoreProjectData projectData, boolean allVersions, boolean transitive, String parentEvent)
     {
-        String parentEventId = ParentEventBuilder.build(projectData.getGroupId(), projectData.getArtifactId(), ALL, parentEvent);
+        String parentEventId = ParentEvent.build(projectData.getGroupId(), projectData.getArtifactId(), ALL, parentEvent);
         MetadataEventResponse response = new MetadataEventResponse();
 
         String projectArtifacts = String.format("%s: [%s-%s]", projectData.getProjectId(), projectData.getGroupId(), projectData.getArtifactId());

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshService.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshService.java
@@ -102,7 +102,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
 
     protected ArtifactsRefreshService artifactsRefreshService = new ArtifactsRefreshServiceImpl(projectsService, repositoryServices, queue, versionHandler);
 
-    protected NotificationsQueueManager notificationsQueueManager = new NotificationsQueueManager(projectsService,new NotificationsMongo(mongoProvider),queue, versionHandler);
+    protected NotificationsQueueManager notificationsQueueManager = new NotificationsQueueManager(new NotificationsMongo(mongoProvider),queue, versionHandler);
 
 
     @Before
@@ -143,7 +143,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
         MetadataEventResponse response = artifactsRefreshService.refreshMasterSnapshotForProject(TEST_GROUP_ID, "art101",true,true,PARENT_EVENT_ID);
         Assert.assertNotNull(response);
         notificationsQueueManager.handleAll();
-        Assert.assertTrue(refreshStatusStore.find(TEST_GROUP_ID, "art101", MASTER_SNAPSHOT, true).isEmpty());
+        Assert.assertTrue(refreshStatusStore.find(TEST_GROUP_ID, "art101", MASTER_SNAPSHOT).isEmpty());
         Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
         Assert.assertEquals(0, projectsVersionsStore.find(TEST_GROUP_ID, "art101").stream().filter(x -> !x.getVersionId().equals(MASTER_SNAPSHOT)).collect(Collectors.toList()).size());
         List<Entity> entities = entitiesStore.getEntities(TEST_GROUP_ID, "art101", MASTER_SNAPSHOT, false);
@@ -217,7 +217,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
 
         List<RefreshStatus> statuses = refreshStatusStore.getAll();
         Assert.assertNotNull(statuses);
-        Assert.assertEquals(2,statuses.size());
+        Assert.assertTrue(statuses.isEmpty());
     }
 
     @Test
@@ -244,7 +244,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
         Assert.assertTrue(entitiesStore.getAllStoredEntities().isEmpty());
         Assert.assertTrue(entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.0.0").isEmpty());
         Assert.assertTrue(entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, "1.0.0").isEmpty());
-        refreshStatusStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,"ALL",true);
+        refreshStatusStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,"ALL");
         MetadataEventResponse response = artifactsRefreshService.refreshAllVersionsForProject(TEST_GROUP_ID, TEST_ARTIFACT_ID, true, true,true,PARENT_EVENT_ID);
         Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
 
@@ -260,7 +260,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
         Assert.assertEquals(2, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, "1.0.0").size());
         List<RefreshStatus> statuses = refreshStatusStore.getAll();
         Assert.assertNotNull(statuses);
-        Assert.assertEquals(6,statuses.size());
+        Assert.assertTrue(statuses.isEmpty());
 
     }
 
@@ -308,7 +308,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
 
         List<RefreshStatus> statuses = refreshStatusStore.getAll();
         Assert.assertNotNull(statuses);
-        Assert.assertEquals(10,statuses.size());
+        Assert.assertTrue(statuses.isEmpty());
 
         MetadataEventResponse partialUpdate = artifactsRefreshService.refreshAllVersionsForAllProjects(false,false,true,PARENT_EVENT_ID);
         Assert.assertEquals(3,notificationsQueueManager.getAllInQueue().size());
@@ -337,7 +337,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
         Assert.assertEquals(2, dependencies.size());
         List<RefreshStatus> statuses = refreshStatusStore.getAll();
         Assert.assertNotNull(statuses);
-        Assert.assertEquals(3,statuses.size());
+        Assert.assertTrue(statuses.isEmpty());
 
     }
 

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceExceptionEscenarios.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceExceptionEscenarios.java
@@ -17,7 +17,6 @@ package org.finos.legend.depot.store.artifacts.services;
 
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryException;
-import org.finos.legend.depot.artifacts.repository.domain.ArtifactDependency;
 import org.finos.legend.depot.artifacts.repository.domain.ArtifactType;
 import org.finos.legend.depot.artifacts.repository.services.RepositoryServices;
 import org.finos.legend.depot.domain.api.MetadataEventResponse;
@@ -56,10 +55,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceWithMocks.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceWithMocks.java
@@ -17,11 +17,8 @@ package org.finos.legend.depot.store.artifacts.services;
 
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryException;
-import org.finos.legend.depot.artifacts.repository.domain.ArtifactDependency;
 import org.finos.legend.depot.artifacts.repository.domain.ArtifactType;
 import org.finos.legend.depot.artifacts.repository.services.RepositoryServices;
-import org.finos.legend.depot.domain.api.MetadataEventResponse;
-import org.finos.legend.depot.domain.api.status.MetadataEventStatus;
 import org.finos.legend.depot.domain.project.IncludeProjectPropertiesConfiguration;
 import org.finos.legend.depot.domain.project.StoreProjectData;
 import org.finos.legend.depot.domain.project.StoreProjectVersionData;
@@ -55,10 +52,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
 import static org.mockito.Mockito.mock;

--- a/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/RepositoryModule.java
+++ b/legend-depot-artifacts-repository-api/src/main/java/org/finos/legend/depot/artifacts/repository/RepositoryModule.java
@@ -24,13 +24,12 @@ import org.finos.legend.depot.schedules.services.SchedulesFactory;
 import org.finos.legend.depot.tracing.api.PrometheusMetricsHandler;
 
 import javax.inject.Named;
-import java.time.LocalDateTime;
 
+import static org.finos.legend.depot.artifacts.repository.services.RepositoryServices.MISSING_REPO_VERSIONS;
 import static org.finos.legend.depot.artifacts.repository.services.RepositoryServices.MISSING_STORE_VERSIONS;
 import static org.finos.legend.depot.artifacts.repository.services.RepositoryServices.PROJECTS;
 import static org.finos.legend.depot.artifacts.repository.services.RepositoryServices.REPO_EXCEPTIONS;
 import static org.finos.legend.depot.artifacts.repository.services.RepositoryServices.REPO_VERSIONS;
-import static org.finos.legend.depot.artifacts.repository.services.RepositoryServices.MISSING_REPO_VERSIONS;
 import static org.finos.legend.depot.artifacts.repository.services.RepositoryServices.STORE_VERSIONS;
 
 public class RepositoryModule extends PrivateModule
@@ -59,7 +58,7 @@ public class RepositoryModule extends PrivateModule
         metricsHandler.registerGauge(MISSING_REPO_VERSIONS, MISSING_REPO_VERSIONS);
         metricsHandler.registerGauge(MISSING_STORE_VERSIONS, MISSING_STORE_VERSIONS);
         metricsHandler.registerGauge(REPO_EXCEPTIONS, REPO_EXCEPTIONS);
-        schedulesFactory.register(REPOSITORY_METRICS_SCHEDULE, LocalDateTime.now().plusMinutes(1), 300000, true,repositoryServices::findVersionsMismatches);
+        schedulesFactory.register(REPOSITORY_METRICS_SCHEDULE, 5 * SchedulesFactory.MINUTE, 5 * SchedulesFactory.MINUTE,repositoryServices::findVersionsMismatches);
         return true;
     }
 }

--- a/legend-depot-artifacts-repository-api/src/test/java/org/finos/legend/depot/artifacts/repository/services/TestVersionsMismatch.java
+++ b/legend-depot-artifacts-repository-api/src/test/java/org/finos/legend/depot/artifacts/repository/services/TestVersionsMismatch.java
@@ -17,8 +17,8 @@ package org.finos.legend.depot.artifacts.repository.services;
 
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepository;
 import org.finos.legend.depot.artifacts.repository.api.ArtifactRepositoryException;
-import org.finos.legend.depot.domain.project.StoreProjectData;
 import org.finos.legend.depot.artifacts.repository.domain.VersionMismatch;
+import org.finos.legend.depot.domain.project.StoreProjectData;
 import org.finos.legend.depot.domain.project.StoreProjectVersionData;
 import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
@@ -26,10 +26,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.ArrayList;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/resources/InfoResource.java
+++ b/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/resources/InfoResource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.finos.legend.depot.domain.DatesHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,6 +145,7 @@ public class InfoResource
         private final long totalMemory;
         private final long maxMemory;
         private final long usedMemory;
+        private final String serverTimeZone;
         private final InfoResource.ServerPlatformInfo platform;
 
         private ServerInfo(String hostName, InfoResource.PlatformVersionInfo platformVersionInfo)
@@ -153,6 +155,7 @@ public class InfoResource
             this.totalMemory = Runtime.getRuntime().totalMemory() / MEGABYTE;
             this.maxMemory = Runtime.getRuntime().maxMemory() / MEGABYTE;
             this.usedMemory = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / MEGABYTE;
+            this.serverTimeZone = DatesHandler.ZONE_ID.getId();
         }
 
         public String getHostName()
@@ -178,6 +181,11 @@ public class InfoResource
         public InfoResource.ServerPlatformInfo getPlatform()
         {
             return this.platform;
+        }
+
+        public String getServerTimeZone()
+        {
+            return serverTimeZone;
         }
     }
 

--- a/legend-depot-core-schedules/src/main/java/org/finos/legend/depot/schedules/SchedulesModule.java
+++ b/legend-depot-core-schedules/src/main/java/org/finos/legend/depot/schedules/SchedulesModule.java
@@ -18,8 +18,9 @@ package org.finos.legend.depot.schedules;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import org.finos.legend.depot.store.admin.api.schedules.SchedulesStore;
 import org.finos.legend.depot.schedules.services.SchedulesFactory;
+import org.finos.legend.depot.store.admin.api.schedules.ScheduleInstancesStore;
+import org.finos.legend.depot.store.admin.api.schedules.SchedulesStore;
 
 public class SchedulesModule extends PrivateModule
 {
@@ -31,9 +32,9 @@ public class SchedulesModule extends PrivateModule
 
     @Provides
     @Singleton
-    public SchedulesFactory getFactory(SchedulesStore schedulesStore)
+    public SchedulesFactory getFactory(SchedulesStore schedulesStore, ScheduleInstancesStore instancesStore)
     {
-        return new SchedulesFactory(schedulesStore);
+        return new SchedulesFactory(schedulesStore, instancesStore);
     }
 
 }

--- a/legend-depot-core-schedules/src/test/java/org/finos/legend/depot/schedules/services/MockInstancesStore.java
+++ b/legend-depot-core-schedules/src/test/java/org/finos/legend/depot/schedules/services/MockInstancesStore.java
@@ -1,0 +1,55 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.schedules.services;
+
+import org.finos.legend.depot.store.admin.api.schedules.ScheduleInstancesStore;
+import org.finos.legend.depot.store.admin.domain.schedules.ScheduleInstance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class MockInstancesStore implements ScheduleInstancesStore
+{
+    List<ScheduleInstance> instances = new ArrayList<>();
+    int ids = 1;
+
+    @Override
+    public void insert(ScheduleInstance instance)
+    {
+         instance.setId(String.valueOf(ids));
+         ids++;
+         instances.add(instance);
+    }
+
+    @Override
+    public void delete(String instanceId)
+    {
+        instances.removeIf(i -> instanceId.equals(i.getId()));
+    }
+
+    @Override
+    public List<ScheduleInstance> find(String scheduleName)
+    {
+        return instances.stream().filter(i -> i.getSchedule().equals(scheduleName)).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ScheduleInstance> getAll()
+    {
+        return instances;
+    }
+}

--- a/legend-depot-core-schedules/src/test/java/org/finos/legend/depot/schedules/services/MockScheduleStore.java
+++ b/legend-depot-core-schedules/src/test/java/org/finos/legend/depot/schedules/services/MockScheduleStore.java
@@ -1,0 +1,55 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.schedules.services;
+
+import org.finos.legend.depot.store.admin.api.schedules.SchedulesStore;
+import org.finos.legend.depot.store.admin.domain.schedules.ScheduleInfo;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+class MockScheduleStore implements SchedulesStore
+{
+    Map<String, ScheduleInfo> schedules = new HashMap<>();
+
+    @Override
+    public Optional<ScheduleInfo> get(String name)
+    {
+        return schedules.containsKey(name) ? Optional.of(schedules.get(name)) : Optional.empty();
+    }
+
+    @Override
+    public List<ScheduleInfo> getAll()
+    {
+        return schedules.values().stream().collect(Collectors.toList());
+    }
+
+    @Override
+    public ScheduleInfo createOrUpdate(ScheduleInfo scheduleInfo)
+    {
+        schedules.put(scheduleInfo.name, scheduleInfo);
+        return scheduleInfo;
+    }
+
+    @Override
+    public void delete(String name)
+    {
+        schedules.remove(name);
+    }
+}

--- a/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/tracing/resources/ResourceLoggingAndTracing.java
+++ b/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/tracing/resources/ResourceLoggingAndTracing.java
@@ -21,7 +21,6 @@ public class ResourceLoggingAndTracing
     public static final String GET_PROJECT_CONFIG_BY_GA = "get project configuration by ga";
     public static final String GET_ALL_LEGACY_PROJECTS = "get all projects legacy";
     public static final String GET_PROJECT_BY_GA = "get project by ga";
-    public static final String GET_PROJECT_BY_ID = "get project by project id";
     public static final String GET_PROJECT_VERSIONS_BY_GA = "get project versions by ga";
     public static final String FIND_PROJECT_VERSIONS = "find project versions by excluded flag";
     public static final String GET_PROJECT_VERSION_BY_GAV = "get project version by gav";
@@ -41,7 +40,6 @@ public class ResourceLoggingAndTracing
     public static final String GET_VERSION_DEPENDENCY_ENTITIES = "get version dependencies entities";
     public static final String GET_REVISION_DEPENDENCY_ENTITIES = "get latest dependencies entities";
     public static final String GET_VERSION_STORE_ENTITIES = "get stored version entities";
-    public static final String DELETE_STORE_ENTITIES = "delete entities";
     public static final String GET_VERSION_ENTITIES_AS_PMCD = "get version entities as PMCD";
     public static final String GET_VERSION_ENTITY = "get version entity";
     public static final String GET_VERSION_ENTITIES_BY_PACKAGE = "get version entities by package";
@@ -64,25 +62,26 @@ public class ResourceLoggingAndTracing
     public static final String GET_VERSION_FILE_GENERATION_BY_FILEPATH = "get version file generations by file";
     public static final String GET_ALL_EVENTS_IN_QUEUE = "get all queue events";
     public static final String FIND_PAST_EVENTS = "find past events";
-    public static final String ENQUEUE_EVENT = "enqueue event";
+    public static final String ENQUEUE_EVENT = "queue event";
     public static final String HANDLE_EVENTS_IN_QUEUE = "handle queue events";
     public static final String STORE_STATUS = "get store status";
-    public static final String TOGGLE_STORE_STATUS = "toggle store status";
     public static final String SCHEDULES_STATUS = "get schedule status";
+    public static final String SCHEDULES_RUNS = "get schedule runs";
     public static final String TRIGGER_SCHEDULE = "trigger schedule";
     public static final String GET_CACHE_STATUS = "cache status";
     public static final String GET_PROJECT_CACHE_STATUS = "project cache status";
     public static final String GET_VERSIONS_BY_LAST_USED = "versions last used";
     public static final String TOGGLE_SCHEDULE = "toggle schedule";
+    public static final String TOGGLE_SCHEDULES = "toggle schedules";
     public static final String ORPHAN_STORE_ENTITIES = "get orphaned entities";
     public static final String GET_ENTITIES_BY_CLASSIFIER_PATH = "get entities by classifier path";
     public static final String REPOSITORY_PROJECT_VERSIONS = "repo project versions";
     public static final String GET_PROJECT_CACHE_MISMATCHES = "version mismatch";
-    public static final String UPDATE_SCHEDULE = "update schedule";
     public static final String FIX_MISSING_VERSIONS = "fix missing versions";
     public static final String FIND_EVENT_BY_ID = "find event";
     public static final String GET_EVENT_IN_QUEUE = "find event in queue";
     public static final String DELETE_SCHEDULE = "delete schedule";
+    public static final String DELETE_SCHEDULES = "delete schedules";
     public static final String GET_QUEUE_COUNT = "queue count";
 
 

--- a/legend-depot-model/src/main/java/org/finos/legend/depot/domain/DatesHandler.java
+++ b/legend-depot-model/src/main/java/org/finos/legend/depot/domain/DatesHandler.java
@@ -1,0 +1,61 @@
+//  Copyright 2021 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package org.finos.legend.depot.domain;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+
+public class DatesHandler
+{
+    public static final ZoneId ZONE_ID = ZoneId.systemDefault();
+
+    public static long toTime(LocalDateTime date)
+    {
+        return Date.from(date.atZone(ZONE_ID).toInstant()).getTime();
+    }
+
+    public static LocalDateTime toDate(Date date)
+    {
+        return toDate(date.getTime());
+    }
+
+    public static LocalDateTime toDate(long time)
+    {
+        return Instant.ofEpochMilli(time).atZone(ZONE_ID).toLocalDateTime();
+    }
+
+    public static Date toDate(LocalDateTime date)
+    {
+        return Date.from(date.atZone(ZONE_ID).toInstant());
+    }
+
+
+    public static LocalDateTime parseDate(String dateString)
+    {
+        try
+        {
+            return LocalDateTime.parse(dateString,DateTimeFormatter.ISO_DATE_TIME);
+        }
+        catch (DateTimeParseException exception)
+        {
+            return LocalDateTime.from(Instant.ofEpochMilli(Long.parseLong(dateString)).atZone(ZONE_ID));
+        }
+    }
+}

--- a/legend-depot-model/src/main/java/org/finos/legend/depot/domain/notifications/MetadataNotification.java
+++ b/legend-depot-model/src/main/java/org/finos/legend/depot/domain/notifications/MetadataNotification.java
@@ -55,7 +55,9 @@ public class MetadataNotification extends VersionedData implements HasIdentifier
     @JsonProperty
     private Date created;
     @JsonProperty
-    private Date lastUpdated;
+    private Date updated;
+    @JsonProperty
+    private Date completed;
     @EqualsExclude
     @JsonProperty
     private Map<Integer,MetadataEventResponse> responses;
@@ -75,37 +77,39 @@ public class MetadataNotification extends VersionedData implements HasIdentifier
                                 @JsonProperty(value = "attempt") Integer attempt,
                                 @JsonProperty(value = "maxAttempts") Integer maxAttempts,
                                 @JsonProperty(value = "responses") Map<Integer,MetadataEventResponse> responses,
-                                @JsonProperty(value = "createdAt") Date createdAt,
-                                @JsonProperty(value = "lastUpdated") Date lastUpdated,
+                                @JsonProperty(value = "created") Date created,
+                                @JsonProperty(value = "updated") Date updated,
+                                @JsonProperty(value = "completed") Date completed,
                                 @JsonProperty(value = "eventPriority") EventPriority eventPriority)
     {
         super(groupId,artifactId,version);
         this.projectId = projectId;
         this.eventId = eventId;
         this.parentEventId = parentEventId;
-        this.lastUpdated = lastUpdated;
-        this.created = createdAt;
+        this.updated = updated;
+        this.created = created;
         this.maxAttempts = maxAttempts != null ? maxAttempts : DEFAULT_MAX_ATTEMPTS;
         this.responses = responses != null ? responses : new HashMap<>();
         this.attempt = attempt != null ? attempt : 0;
         this.fullUpdate = fullUpdate != null ? fullUpdate : false;
         this.transitive = transitive != null ? transitive : false;
         this.eventPriority = eventPriority;
+        this.completed = completed;
     }
 
     public MetadataNotification(String projectId, String groupId, String artifactId, String versionId)
     {
-        this(projectId, groupId, artifactId, versionId, null, null, null, null, null, null, null, null, null, EventPriority.LOW);
+        this(projectId, groupId, artifactId, versionId, null, null, null, null, null, null, null, null,null,null, EventPriority.LOW);
     }
 
     public MetadataNotification(String projectId,String groupId, String artifactId, String versionId, Boolean fullUpdate,Boolean transitive, String parentEvent)
     {
-        this(projectId, groupId, artifactId, versionId, null, parentEvent, fullUpdate, transitive, null, null, null, null, null, EventPriority.LOW);
+        this(projectId, groupId, artifactId, versionId, null, parentEvent, fullUpdate, transitive, null, null, null,null,null,null, EventPriority.LOW);
     }
 
     public MetadataNotification(String projectId,String groupId, String artifactId, String versionId, Boolean fullUpdate,Boolean transitive, String parentEvent, EventPriority eventPriority)
     {
-        this(projectId, groupId, artifactId, versionId, null, parentEvent, fullUpdate, transitive, null, null, null, null, null, eventPriority);
+        this(projectId, groupId, artifactId, versionId, null, parentEvent, fullUpdate, transitive, null, null, null, null,null, null,eventPriority);
     }
 
     public MetadataNotification()
@@ -131,6 +135,21 @@ public class MetadataNotification extends VersionedData implements HasIdentifier
     {
         this.eventId = eventID;
         return this;
+    }
+
+    public Date getCompleted()
+    {
+        return completed;
+    }
+
+    public void setCompleted(Date completed)
+    {
+        this.completed = completed;
+    }
+
+    public void setEventPriority(EventPriority eventPriority)
+    {
+        this.eventPriority = eventPriority;
     }
 
     public boolean isFullUpdate()
@@ -196,6 +215,11 @@ public class MetadataNotification extends VersionedData implements HasIdentifier
         return transitive;
     }
 
+    public MetadataNotification complete()
+    {
+        this.completed = new Date();
+        return this;
+    }
 
     public MetadataNotification increaseAttempts()
     {
@@ -255,14 +279,14 @@ public class MetadataNotification extends VersionedData implements HasIdentifier
         return getResponses().get(attempt);
     }
 
-    public Date getLastUpdated()
+    public Date getUpdated()
     {
-        return lastUpdated;
+        return updated;
     }
 
-    public MetadataNotification setLastUpdated(Date lastUpdated)
+    public MetadataNotification setUpdated(Date updated)
     {
-        this.lastUpdated = lastUpdated;
+        this.updated = updated;
         return this;
     }
 

--- a/legend-depot-model/src/test/java/org/finos/legend/depot/domain/DatesHandlerTest.java
+++ b/legend-depot-model/src/test/java/org/finos/legend/depot/domain/DatesHandlerTest.java
@@ -13,21 +13,23 @@
 //  limitations under the License.
 //
 
+package org.finos.legend.depot.domain;
 
-package org.finos.legend.depot.store.admin.api.schedules;
+import org.junit.Assert;
+import org.junit.Test;
 
-import org.finos.legend.depot.store.admin.domain.schedules.ScheduleInfo;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
-import java.util.List;
-import java.util.Optional;
-
-public interface SchedulesStore
+public class DatesHandlerTest
 {
-    List<ScheduleInfo> getAll();
+    @Test
+    public void canGetEventByEpocMillis()
+    {
 
-    Optional<ScheduleInfo> get(String name);
+        LocalDateTime date = DatesHandler.parseDate("1679411706436");
+        LocalDateTime lunchTime = LocalDateTime.parse("2023-03-21T14:02:49", DateTimeFormatter.ISO_DATE_TIME);
+        Assert.assertNotNull(date);
 
-    ScheduleInfo createOrUpdate(ScheduleInfo scheduleInfo);
-
-    void delete(String name);
+    }
 }

--- a/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/admin/api/artifacts/RefreshStatusStore.java
+++ b/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/admin/api/artifacts/RefreshStatusStore.java
@@ -17,7 +17,6 @@ package org.finos.legend.depot.store.admin.api.artifacts;
 
 import org.finos.legend.depot.store.admin.domain.artifacts.RefreshStatus;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,28 +24,19 @@ public interface RefreshStatusStore
 {
     Optional<RefreshStatus> get(String groupId, String artifactId, String version);
 
-    List<RefreshStatus> find(String groupId, String artifactId, String version,String eventId, String parentEventId,Boolean running, Boolean success, LocalDateTime startTimeFrom,LocalDateTime startTimeTo);
+    List<RefreshStatus> find(String groupId, String artifactId, String version,String eventId, String parentEventId);
 
     List<RefreshStatus> getAll();
 
-    default List<RefreshStatus> find(LocalDateTime from, LocalDateTime to)
-    {
-        return  find(null,null,null,null,null,null,null,from,to);
-    }
-
     default List<RefreshStatus> find(String groupId, String artifactId, String version)
     {
-        return  find(groupId,artifactId,version,null,null,null,null,null,null);
+        return  find(groupId,artifactId,version,null,null);
     }
 
-    default List<RefreshStatus> find(String groupId, String artifactId, String version, Boolean running)
-    {
-        return  find(groupId,artifactId,version,null,null,running,null,null,null);
-    }
+    void insert(RefreshStatus status);
 
     RefreshStatus createOrUpdate(RefreshStatus storeStatus);
 
-    void delete(String statusId);
+    void delete(String groupId, String artifactId, String versionId);
 
-    long deleteOldRefreshStatuses(int days);
 }

--- a/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/admin/api/schedules/ScheduleInstancesStore.java
+++ b/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/admin/api/schedules/ScheduleInstancesStore.java
@@ -13,14 +13,21 @@
 //  limitations under the License.
 //
 
-package org.finos.legend.depot.store.artifacts.api;
 
-public final class ParentEventBuilder
+package org.finos.legend.depot.store.admin.api.schedules;
+
+import org.finos.legend.depot.store.admin.domain.schedules.ScheduleInstance;
+
+import java.util.List;
+
+public interface ScheduleInstancesStore
 {
-    private static final String SEPARATOR = "-";
+    List<ScheduleInstance> getAll();
 
-    public static String build(String groupId, String artifactId, String versionId,String parentEventId)
-    {
-        return parentEventId != null ? parentEventId : groupId + SEPARATOR + artifactId + SEPARATOR + versionId;
-    }
+    List<ScheduleInstance> find(String scheduleName);
+
+    void insert(ScheduleInstance instance);
+
+    void delete(String instanceId);
+
 }

--- a/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/admin/domain/artifacts/RefreshStatus.java
+++ b/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/admin/domain/artifacts/RefreshStatus.java
@@ -18,34 +18,22 @@ package org.finos.legend.depot.store.admin.domain.artifacts;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.finos.legend.depot.domain.api.MetadataEventResponse;
 import org.finos.legend.depot.domain.notifications.EventPriority;
 import org.finos.legend.depot.domain.notifications.MetadataNotification;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Map;
+
+import static org.finos.legend.depot.domain.DatesHandler.toDate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RefreshStatus extends MetadataNotification
 {
     @JsonProperty
-    @EqualsExclude
-    private boolean running;
-    @JsonProperty
-    @EqualsExclude
-    private Date startTime;
-    @JsonProperty
-    @EqualsExclude
-    private Date lastRun;
-    @JsonProperty
-    @EqualsExclude
-    private long duration;
-    @JsonProperty
-    @EqualsExclude
-    private String traceId;
-
+    private Date expires = toDate(LocalDateTime.now().plusMinutes(15));
 
     public RefreshStatus()
     {
@@ -54,12 +42,7 @@ public class RefreshStatus extends MetadataNotification
 
     public RefreshStatus(String projectId, String groupId, String artifactId, String version, String eventId, String parentEventId, Boolean fullUpdate, Boolean transitive, Integer attempt, Integer maxAttempts, Map<Integer,MetadataEventResponse> responses, Date createdAt, Date lastUpdated, EventPriority eventPriority)
     {
-        super(projectId, groupId, artifactId, version, eventId, parentEventId, fullUpdate, transitive, attempt, maxAttempts, responses, createdAt, lastUpdated, eventPriority);
-    }
-
-    public RefreshStatus(String projectId, String groupId, String artifactId, String versionId)
-    {
-        super(projectId, groupId, artifactId, versionId);
+        super(projectId, groupId, artifactId, version, eventId, parentEventId, fullUpdate, transitive, attempt, maxAttempts, responses, createdAt, lastUpdated, null,eventPriority);
     }
 
     public RefreshStatus(String groupId, String artifactId, String version)
@@ -67,79 +50,20 @@ public class RefreshStatus extends MetadataNotification
         super(null,groupId, artifactId, version);
     }
 
-    public boolean isRunning()
+    public Date getExpires()
     {
-        return running;
+        return expires;
     }
 
-    public void setRunning(boolean running)
+    public void setExpires(Date expires)
     {
-        this.running = running;
+        this.expires = expires;
     }
 
-    public Date getLastRun()
+    @JsonProperty
+    public boolean isExpired()
     {
-        return lastRun;
-    }
-
-    public void setLastRun(Date lastRun)
-    {
-        this.lastRun = lastRun;
-    }
-
-    public Date getStartTime()
-    {
-        return startTime;
-    }
-
-    public void setStartTime(Date startTime)
-    {
-        this.startTime = startTime;
-    }
-
-    public long getDuration()
-    {
-        return duration;
-    }
-
-    public void setDuration(long duration)
-    {
-        this.duration = duration;
-    }
-
-    public String getTraceId()
-    {
-        return traceId;
-    }
-
-    public void setTraceId(String traceId)
-    {
-        this.traceId = traceId;
-    }
-
-    public RefreshStatus withStartTime(Date startTime)
-    {
-        this.startTime = startTime;
-        return this;
-    }
-
-    public RefreshStatus startRunning()
-    {
-        this.running = true;
-        this.startTime = new Date();
-        this.duration = 0;
-        return this;
-    }
-
-    public RefreshStatus stopRunning()
-    {
-        this.running = false;
-        this.lastRun = new Date();
-        if (this.startTime != null)
-        {
-            this.duration = lastRun.getTime() - startTime.getTime();
-        }
-        return this;
+        return new Date().after(expires);
     }
 
     @Override
@@ -174,7 +98,8 @@ public class RefreshStatus extends MetadataNotification
                 event.getMaxAttempts(),
                 event.getResponses(),
                 event.getCreated(),
-                event.getLastUpdated(),
+                event.getUpdated(),
                 event.getEventPriority());
     }
+
 }

--- a/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/admin/domain/schedules/ScheduleInstance.java
+++ b/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/admin/domain/schedules/ScheduleInstance.java
@@ -19,29 +19,29 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.finos.legend.depot.domain.HasIdentifier;
 
+import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ScheduleInfo implements HasIdentifier
+public class ScheduleInstance implements HasIdentifier
 {
-    @JsonProperty
-    public String id;
-    @JsonProperty
-    public String name;
-    @JsonProperty
-    public boolean disabled = false;
-    @JsonProperty
-    public Boolean singleInstance;
-    @JsonProperty
-    public Long frequency;
 
-    public ScheduleInfo()
+    @JsonProperty
+    private String id;
+    @JsonProperty
+    private String schedule;
+    @JsonProperty
+    private Date expires;
+
+    public ScheduleInstance()
     {
     }
 
-    public ScheduleInfo(String name)
+    public ScheduleInstance(String name, Date expires)
     {
-        this.name = name;
+        this.schedule = name;
+        this.expires = expires;
     }
+
 
     @Override
     public String getId()
@@ -49,48 +49,33 @@ public class ScheduleInfo implements HasIdentifier
         return id;
     }
 
+    public Date getExpires()
+    {
+        return expires;
+    }
+
+    public void setExpires(Date expires)
+    {
+        this.expires = expires;
+    }
+
     public void setId(String id)
     {
         this.id = id;
     }
 
-    public String getName()
+    public String getSchedule()
     {
-        return name;
+        return schedule;
     }
 
-    public void setName(String name)
+    public void setSchedule(String schedule)
     {
-        this.name = name;
+        this.schedule = schedule;
     }
 
-    public boolean isDisabled()
+    public boolean isExpired()
     {
-        return disabled;
-    }
-
-    public void setDisabled(boolean disabled)
-    {
-        this.disabled = disabled;
-    }
-
-    public Boolean getSingleInstance()
-    {
-        return singleInstance;
-    }
-
-    public void setSingleInstance(Boolean singleInstance)
-    {
-        this.singleInstance = singleInstance;
-    }
-
-    public Long getFrequency()
-    {
-        return frequency;
-    }
-
-    public void setFrequency(Long frequency)
-    {
-        this.frequency = frequency;
+        return new Date().after(expires);
     }
 }

--- a/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/api/generation/file/UpdateFileGenerations.java
+++ b/legend-depot-store-api/src/main/java/org/finos/legend/depot/store/api/generation/file/UpdateFileGenerations.java
@@ -22,6 +22,6 @@ public interface UpdateFileGenerations extends FileGenerations
 
     StoredFileGeneration createOrUpdate(StoredFileGeneration detail);
 
-    boolean delete(String groupId, String artifactId, String versionId);
+    long delete(String groupId, String artifactId, String versionId);
 
 }

--- a/legend-depot-store-metrics/src/main/java/org/finos/legend/depot/store/metrics/MetricsModule.java
+++ b/legend-depot-store-metrics/src/main/java/org/finos/legend/depot/store/metrics/MetricsModule.java
@@ -22,7 +22,6 @@ import org.finos.legend.depot.schedules.services.SchedulesFactory;
 import org.finos.legend.depot.store.metrics.services.QueryMetricsHandler;
 
 import javax.inject.Named;
-import java.time.LocalDateTime;
 
 public class MetricsModule extends PrivateModule
 {
@@ -39,7 +38,7 @@ public class MetricsModule extends PrivateModule
     @Named("persist-metrics")
     boolean scheduleMetricsPersistence(SchedulesFactory schedulesFactory, QueryMetricsHandler queryMetrics)
     {
-        schedulesFactory.register("persist-metrics", LocalDateTime.now().plusMinutes(1), 20160 * 60000L, true, () ->
+        schedulesFactory.register("persist-metrics", SchedulesFactory.MINUTE, 2016000 * SchedulesFactory.MINUTE, () ->
         {
             queryMetrics.persistMetrics();
             return true;

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/admin/AdminDataStoreMongoModule.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/admin/AdminDataStoreMongoModule.java
@@ -17,8 +17,10 @@ package org.finos.legend.depot.store.mongo.admin;
 
 import com.google.inject.PrivateModule;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
+import org.finos.legend.depot.store.admin.api.schedules.ScheduleInstancesStore;
 import org.finos.legend.depot.store.admin.api.schedules.SchedulesStore;
 import org.finos.legend.depot.store.mongo.admin.metrics.QueryMetricsMongo;
+import org.finos.legend.depot.store.mongo.admin.schedules.ScheduleInstancesMongo;
 import org.finos.legend.depot.store.mongo.admin.schedules.SchedulesMongo;
 
 public class AdminDataStoreMongoModule extends PrivateModule
@@ -28,9 +30,11 @@ public class AdminDataStoreMongoModule extends PrivateModule
     {
 
         bind(SchedulesStore.class).to(SchedulesMongo.class);
+        bind(ScheduleInstancesStore.class).to(ScheduleInstancesMongo.class);
         bind(QueryMetricsStore.class).to(QueryMetricsMongo.class);
 
         expose(QueryMetricsStore.class);
         expose(SchedulesStore.class);
+        expose(ScheduleInstancesStore.class);
     }
 }

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/admin/MongoAdminStore.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/admin/MongoAdminStore.java
@@ -22,12 +22,13 @@ import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
 import org.finos.legend.depot.store.mongo.admin.artifacts.ArtifactsFilesMongo;
 import org.finos.legend.depot.store.mongo.admin.artifacts.ArtifactsRefreshStatusMongo;
+import org.finos.legend.depot.store.mongo.admin.metrics.QueryMetricsMongo;
 import org.finos.legend.depot.store.mongo.admin.migrations.ProjectToProjectVersionMigration;
+import org.finos.legend.depot.store.mongo.admin.schedules.ScheduleInstancesMongo;
 import org.finos.legend.depot.store.mongo.admin.schedules.SchedulesMongo;
 import org.finos.legend.depot.store.mongo.entities.EntitiesMongo;
 import org.finos.legend.depot.store.mongo.generation.file.FileGenerationsMongo;
 import org.finos.legend.depot.store.mongo.projects.ProjectsMongo;
-import org.finos.legend.depot.store.mongo.admin.metrics.QueryMetricsMongo;
 import org.finos.legend.depot.store.mongo.projects.ProjectsVersionsMongo;
 
 import javax.inject.Inject;
@@ -91,6 +92,7 @@ public class MongoAdminStore
         results.addAll(createIndexesIfAbsent(mongoDatabase,ArtifactsFilesMongo.COLLECTION,ArtifactsFilesMongo.buildIndexes()));
         results.addAll(createIndexesIfAbsent(mongoDatabase,ArtifactsRefreshStatusMongo.COLLECTION,ArtifactsRefreshStatusMongo.buildIndexes()));
         results.addAll(createIndexesIfAbsent(mongoDatabase,SchedulesMongo.COLLECTION,SchedulesMongo.buildIndexes()));
+        results.addAll(createIndexesIfAbsent(mongoDatabase, ScheduleInstancesMongo.COLLECTION,ScheduleInstancesMongo.buildIndexes()));
         results.addAll(createIndexesIfAbsent(mongoDatabase,QueryMetricsMongo.COLLECTION,QueryMetricsMongo.buildIndexes()));
         return results;
     }

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/admin/schedules/ScheduleInstancesMongo.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/admin/schedules/ScheduleInstancesMongo.java
@@ -21,34 +21,34 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexModel;
 import org.bson.conversions.Bson;
-import org.finos.legend.depot.store.admin.api.schedules.SchedulesStore;
-import org.finos.legend.depot.store.admin.domain.schedules.ScheduleInfo;
+import org.bson.types.ObjectId;
+import org.finos.legend.depot.store.admin.api.schedules.ScheduleInstancesStore;
+import org.finos.legend.depot.store.admin.domain.schedules.ScheduleInstance;
 import org.finos.legend.depot.store.mongo.core.BaseMongo;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import static com.mongodb.client.model.Filters.eq;
 
-public class SchedulesMongo extends BaseMongo<ScheduleInfo> implements SchedulesStore
+public class ScheduleInstancesMongo extends BaseMongo<ScheduleInstance> implements ScheduleInstancesStore
 {
-    public static final String COLLECTION = "schedules";
-    public static final String NAME = "name";
+    public static final String COLLECTION = "schedule-instances";
+    public static final String SCHEDULE = "schedule";
 
 
     @Inject
-    public SchedulesMongo(@Named("mongoDatabase") MongoDatabase databaseProvider)
+    public ScheduleInstancesMongo(@Named("mongoDatabase") MongoDatabase databaseProvider)
     {
-        super(databaseProvider, ScheduleInfo.class, new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_EMPTY));
+        super(databaseProvider, ScheduleInstance.class, new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_EMPTY));
     }
 
     @Override
-    protected void validateNewData(ScheduleInfo data)
+    protected void validateNewData(ScheduleInstance data)
     {
-        //nothing to validate
+
     }
 
     @Override
@@ -58,35 +58,31 @@ public class SchedulesMongo extends BaseMongo<ScheduleInfo> implements Schedules
     }
 
     @Override
-    protected Bson getKeyFilter(ScheduleInfo data)
+    protected Bson getKeyFilter(ScheduleInstance data)
     {
-        return eq(NAME, data.name);
+        return eq(SCHEDULE, data.getSchedule());
     }
 
-
-    @Override
-    public Optional<ScheduleInfo> get(String name)
+    public static List<IndexModel> buildIndexes()
     {
-        return findOne(eq(NAME, name));
+        return Arrays.asList(buildIndex("schedule", SCHEDULE));
     }
 
-
     @Override
-    public List<ScheduleInfo> getAll()
+    public List<ScheduleInstance> getAll()
     {
         return super.getAllStoredEntities();
     }
 
-
     @Override
-    public void delete(String name)
+    public void delete(String instanceId)
     {
-        super.delete(eq(NAME, name));
+        super.delete(eq(ID_FIELD, new ObjectId(instanceId)));
     }
 
-
-    public static List<IndexModel> buildIndexes()
+    @Override
+    public List<ScheduleInstance> find(String scheduleName)
     {
-        return Arrays.asList(buildIndex("name", NAME));
+        return super.find(eq(SCHEDULE, scheduleName));
     }
 }

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/entities/EntitiesMongo.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/entities/EntitiesMongo.java
@@ -38,6 +38,7 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.depot.domain.CoordinateValidator;
+import org.finos.legend.depot.domain.entity.EntityValidationErrors;
 import org.finos.legend.depot.domain.entity.StoredEntity;
 import org.finos.legend.depot.domain.entity.StoredEntityOverview;
 import org.finos.legend.depot.domain.project.ProjectVersion;
@@ -46,7 +47,6 @@ import org.finos.legend.depot.domain.version.VersionValidator;
 import org.finos.legend.depot.store.api.entities.Entities;
 import org.finos.legend.depot.store.api.entities.UpdateEntities;
 import org.finos.legend.depot.store.mongo.core.BaseMongo;
-import org.finos.legend.depot.domain.entity.EntityValidationErrors;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.tools.entity.EntityPaths;
 import org.slf4j.Logger;
@@ -182,7 +182,7 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
                 set(ENTITY_PATH, entity.getEntity().getPath()),
                 set(ENTITY_CLASSIFIER_PATH, entity.getEntity().getClassifierPath()),
                 set(ENTITY_CONTENT, entity.getEntity().getContent()),
-                currentDate(LAST_MODIFIED));
+                currentDate(UPDATED));
     }
 
     private StoreOperationResult validateEntity(StoredEntity entity)

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/generation/file/FileGenerationsMongo.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/generation/file/FileGenerationsMongo.java
@@ -111,11 +111,10 @@ public class FileGenerationsMongo extends BaseMongo<StoredFileGeneration> implem
     }
 
     @Override
-    public boolean delete(String groupId, String artifactId, String versionId)
+    public long delete(String groupId, String artifactId, String versionId)
     {
         return delete(getArtifactAndVersionFilter(groupId, artifactId, versionId));
     }
-
 
 }
 

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/TestStoreMongo.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/TestStoreMongo.java
@@ -25,10 +25,12 @@ import com.mongodb.client.MongoDatabase;
 import de.bwaldvogel.mongo.MongoServer;
 import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
 import org.bson.Document;
+import org.finos.legend.depot.domain.HasIdentifier;
 import org.finos.legend.depot.domain.entity.StoredEntity;
 import org.finos.legend.depot.domain.generation.file.StoredFileGeneration;
-import org.finos.legend.depot.domain.project.StoreProjectVersionData;
 import org.finos.legend.depot.domain.project.StoreProjectData;
+import org.finos.legend.depot.domain.project.StoreProjectVersionData;
+import org.finos.legend.depot.store.mongo.core.BaseMongo;
 import org.finos.legend.depot.store.mongo.entities.EntitiesMongo;
 import org.finos.legend.depot.store.mongo.generation.file.FileGenerationsMongo;
 import org.finos.legend.depot.store.mongo.projects.ProjectsMongo;
@@ -38,9 +40,6 @@ import org.junit.Assert;
 
 import java.io.InputStream;
 import java.net.URL;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
 import java.util.List;
 
 public abstract class TestStoreMongo
@@ -74,6 +73,10 @@ public abstract class TestStoreMongo
         return null;
     }
 
+    protected void insertRaw(String collectionName,HasIdentifier rawObject)
+    {
+        mongoProvider.getCollection(collectionName).insertOne(BaseMongo.buildDocument(rawObject));
+    }
 
     public static List<StoreProjectVersionData> readProjectVersionsConfigsFile(URL fileName)
     {
@@ -258,8 +261,4 @@ public abstract class TestStoreMongo
         return getMongoDatabase().getCollection(ProjectsVersionsMongo.COLLECTION);
     }
 
-    protected Date toDate(LocalDateTime date)
-    {
-        return Date.from(date.atZone(ZoneId.systemDefault()).toInstant());
-    }
 }

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/admin/artifacts/TestMongoStatus.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/admin/artifacts/TestMongoStatus.java
@@ -15,18 +15,10 @@
 
 package org.finos.legend.depot.store.mongo.admin.artifacts;
 
-import org.finos.legend.depot.domain.api.MetadataEventResponse;
 import org.finos.legend.depot.store.admin.domain.artifacts.RefreshStatus;
 import org.finos.legend.depot.store.mongo.TestStoreMongo;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
-import java.util.List;
-
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
 
 public class TestMongoStatus extends TestStoreMongo
 {
@@ -39,100 +31,25 @@ public class TestMongoStatus extends TestStoreMongo
     public void testStatus()
     {
         Assert.assertEquals(0, refreshStatus.getCollection().countDocuments());
-        refreshStatus.createOrUpdate(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0").orElse(new RefreshStatus(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0")).startRunning());
-        Assert.assertEquals(1, refreshStatus.getCollection().countDocuments());
-        refreshStatus.createOrUpdate(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0").get().stopRunning());
+        refreshStatus.insert(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0").orElse(new RefreshStatus(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0")));
         Assert.assertEquals(1, refreshStatus.getCollection().countDocuments());
 
-        Assert.assertNotNull(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0"));
-        Assert.assertFalse(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0").get().isRunning());
-
-        refreshStatus.createOrUpdate(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT).orElse(new RefreshStatus(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT)).startRunning());
-        Assert.assertEquals(2, refreshStatus.getCollection().countDocuments());
-        Assert.assertNotNull(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0"));
-        Assert.assertTrue(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT).get().isRunning());
+        Assert.assertFalse(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0").get().isExpired());
 
     }
-
-    @Test
-    public void canRetrieveStatusFromToDate()
-    {
-        RefreshStatus status1 = new RefreshStatus("test1.org", "TEST", "1.0.0");
-        RefreshStatus status2 = new RefreshStatus("test2.org", "TEST", "1.0.0");
-        RefreshStatus status3 = new RefreshStatus("test3.org", "TEST", "1.0.0");
-        RefreshStatus status4 = new RefreshStatus("test4.org", "TEST", "1.0.0");
-
-        LocalDateTime aPointInTime = LocalDateTime.of(2022, 9, 12, 12, 0).minusDays(12);
-        refreshStatus.createOrUpdate(status1.withStartTime(toDate(aPointInTime)));
-        refreshStatus.createOrUpdate(status2.withStartTime(toDate(aPointInTime.plusHours(1))));
-        refreshStatus.createOrUpdate(status3.withStartTime(toDate(aPointInTime.plusHours(1).plusMinutes(22))));
-        refreshStatus.createOrUpdate(status4.withStartTime(toDate(aPointInTime.plusHours(2).plusMinutes(35))));
-
-        List<RefreshStatus> allstatuss = refreshStatus.getAll();
-        Assert.assertNotNull(allstatuss);
-        Assert.assertEquals(4, allstatuss.size());
-        List<RefreshStatus> statusesBeforeLunch = refreshStatus.find(aPointInTime.toLocalDate().atStartOfDay(), aPointInTime);
-        Assert.assertNotNull(statusesBeforeLunch);
-        Assert.assertEquals(1, statusesBeforeLunch.size());
-        Assert.assertEquals("test1.org", statusesBeforeLunch.get(0).getGroupId());
-
-        List<RefreshStatus> afterLunch = refreshStatus.find(aPointInTime.withHour(12).withMinute(0).withSecond(1), null);
-        Assert.assertNotNull(afterLunch);
-        Assert.assertEquals(3, afterLunch.size());
-
-        List<RefreshStatus> statusInBetween = refreshStatus.find(aPointInTime.plusHours(1).plusMinutes(1),aPointInTime.plusHours(2));
-        Assert.assertNotNull(statusInBetween);
-        Assert.assertEquals(1, statusInBetween.size());
-        Assert.assertEquals("test3.org", statusInBetween.get(0).getGroupId());
-
-
-    }
-
-    @Test
-    public void testFindByStatus()
-    {
-        Assert.assertEquals(0, refreshStatus.getCollection().countDocuments());
-        refreshStatus.createOrUpdate(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0").orElse(new RefreshStatus(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0")).stopRunning());
-        refreshStatus.createOrUpdate(refreshStatus.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.1").orElse((RefreshStatus) new RefreshStatus(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.1").addError("it failed")).stopRunning());
-        Assert.assertEquals(2, refreshStatus.getCollection().countDocuments());
-
-        Assert.assertEquals(2,refreshStatus.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,null).size());
-        Assert.assertEquals("1.0.0",refreshStatus.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,null,null,null,null,true,null,null).get(0).getVersionId());
-        Assert.assertEquals("1.0.1",refreshStatus.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,null,null,null,null,false,null,null).get(0).getVersionId());
-
-    }
-
 
     @Test
     public void testFindByParentId()
     {
         Assert.assertEquals(0, refreshStatus.getCollection().countDocuments());
-        refreshStatus.createOrUpdate(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.0").withParentEventId("test"));
-        refreshStatus.createOrUpdate(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.1").withParentEventId("test"));
-        refreshStatus.createOrUpdate(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.2").withParentEventId("test"));
-        refreshStatus.createOrUpdate(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.3").withParentEventId("test1"));
+        refreshStatus.insert(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.0").withParentEventId("test"));
+        refreshStatus.insert(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.1").withParentEventId("test"));
+        refreshStatus.insert(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.2").withParentEventId("test"));
+        refreshStatus.insert(new RefreshStatus(TEST_GROUP_ID,TEST_ARTIFACT_ID,"0.0.3").withParentEventId("test1"));
         Assert.assertEquals(4, refreshStatus.getCollection().countDocuments());
 
-        Assert.assertEquals(3,refreshStatus.find(null,null,null,null,"test",null,null,null,null).size());
-        Assert.assertEquals(1,refreshStatus.find(null,null,null,null,"test1",null,null,null,null).size());
-
-
-    }
-
-    @Test
-    public void canDeleteOldStatuses()
-    {
-        RefreshStatus status1 = new RefreshStatus("test","artifact","2.0.0");
-        RefreshStatus status2 = new RefreshStatus("test","artifact","1.0.0");
-        status1.setStartTime(Date.from(LocalDateTime.now().minusDays(12).atZone(ZoneId.systemDefault()).toInstant()));
-        status2.setStartTime(Date.from(LocalDateTime.now().minusDays(2).atZone(ZoneId.systemDefault()).toInstant()));
-        refreshStatus.createOrUpdate(status1);
-        refreshStatus.createOrUpdate(status2);
-        Assert.assertEquals(2, refreshStatus.getAll().size());
-        refreshStatus.deleteOldRefreshStatuses(10);
-        Assert.assertEquals(1, refreshStatus.getAll().size());
-        refreshStatus.deleteOldRefreshStatuses(1);
-        Assert.assertEquals(0, refreshStatus.getAll().size());
+        Assert.assertEquals(3,refreshStatus.find(null,null,null,null,"test").size());
+        Assert.assertEquals(1,refreshStatus.find(null,null,null,null,"test1").size());
 
 
     }

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/admin/schedules/TestScheduleStores.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/admin/schedules/TestScheduleStores.java
@@ -13,21 +13,11 @@
 //  limitations under the License.
 //
 
+package org.finos.legend.depot.store.mongo.admin.schedules;
 
-package org.finos.legend.depot.store.admin.api.schedules;
+import org.finos.legend.depot.store.mongo.TestStoreMongo;
 
-import org.finos.legend.depot.store.admin.domain.schedules.ScheduleInfo;
-
-import java.util.List;
-import java.util.Optional;
-
-public interface SchedulesStore
+public class TestScheduleStores extends TestStoreMongo
 {
-    List<ScheduleInfo> getAll();
 
-    Optional<ScheduleInfo> get(String name);
-
-    ScheduleInfo createOrUpdate(ScheduleInfo scheduleInfo);
-
-    void delete(String name);
 }

--- a/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/api/Notifications.java
+++ b/legend-depot-store-notifications/src/main/java/org/finos/legend/depot/store/notifications/api/Notifications.java
@@ -30,9 +30,7 @@ public interface Notifications
 
     List<MetadataNotification> find(String group, String artifact, String version, String eventId,String parentId, Boolean success, LocalDateTime fromDate, LocalDateTime toDate);
 
-    void insert(MetadataNotification metadataEvent);
-
-    void complete(MetadataNotification metadataEvent);
+    MetadataNotification createOrUpdate(MetadataNotification metadataEvent);
 
     void delete(String id);
 }

--- a/legend-depot-store-notifications/src/test/java/org/finos/legend/depot/store/notifications/resources/TestNotificationsResource.java
+++ b/legend-depot-store-notifications/src/test/java/org/finos/legend/depot/store/notifications/resources/TestNotificationsResource.java
@@ -15,15 +15,11 @@
 
 package org.finos.legend.depot.store.notifications.resources;
 
-import org.finos.legend.depot.services.api.projects.ManageProjectsService;
-import org.finos.legend.depot.services.projects.ManageProjectsServiceImpl;
+import org.finos.legend.depot.domain.notifications.MetadataNotification;
 import org.finos.legend.depot.store.mongo.TestStoreMongo;
-import org.finos.legend.depot.store.mongo.projects.ProjectsMongo;
-import org.finos.legend.depot.store.mongo.projects.ProjectsVersionsMongo;
 import org.finos.legend.depot.store.notifications.api.NotificationEventHandler;
 import org.finos.legend.depot.store.notifications.api.NotificationsManager;
 import org.finos.legend.depot.store.notifications.api.Queue;
-import org.finos.legend.depot.domain.notifications.MetadataNotification;
 import org.finos.legend.depot.store.notifications.services.NotificationsQueueManager;
 import org.finos.legend.depot.store.notifications.store.mongo.NotificationsMongo;
 import org.finos.legend.depot.store.notifications.store.mongo.NotificationsQueueMongo;
@@ -31,8 +27,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import static org.finos.legend.depot.domain.DatesHandler.toDate;
 import static org.mockito.Mockito.mock;
 
 
@@ -41,9 +39,9 @@ public class TestNotificationsResource extends TestStoreMongo
     public static final String VERSION = "1.0.0";
     private final NotificationsMongo eventsMongo = new NotificationsMongo(mongoProvider);
     private final Queue queue = new NotificationsQueueMongo(mongoProvider);
-    private final ManageProjectsService projectsService = new ManageProjectsServiceImpl(new ProjectsVersionsMongo(mongoProvider), new ProjectsMongo(mongoProvider));
     private final NotificationEventHandler handler = mock(NotificationEventHandler.class);
-    private final NotificationsManager notificationsManager = new NotificationsQueueManager(projectsService,eventsMongo,queue,handler);
+    private final NotificationsManager notificationsManager = new NotificationsQueueManager(eventsMongo,queue,handler);
+    private final NotificationsManagerResource resource = new NotificationsManagerResource(notificationsManager);
 
     @Test
     public void canRetrieveEventsByDate()
@@ -54,21 +52,40 @@ public class TestNotificationsResource extends TestStoreMongo
         MetadataNotification event3 = new MetadataNotification("testproject3", "test.org", "test", VERSION);
         MetadataNotification event4 = new MetadataNotification("testproject4", "org.test", "test", VERSION);
 
-        LocalDateTime aPointInTime = LocalDateTime.parse("2019-01-01 10:00:00", NotificationsManagerResource.DATE_TIME_FORMATTER);
-        eventsMongo.insert(event1.setLastUpdated(toDate(aPointInTime)));
-        eventsMongo.insert(event2.setLastUpdated(toDate(aPointInTime.plusHours(1))));
-        eventsMongo.insert(event3.setLastUpdated(toDate(aPointInTime.plusHours(2))));
-        eventsMongo.insert(event4.setLastUpdated(toDate(aPointInTime.plusHours(2).plusMinutes(35))));
-        NotificationsManagerResource resource = new NotificationsManagerResource(notificationsManager);
+        LocalDateTime aPointInTime = LocalDateTime.parse("2019-01-01T10:00:00", DateTimeFormatter.ISO_DATE_TIME);
+        insertRaw(eventsMongo.COLLECTION,event1.setUpdated(toDate(aPointInTime)));
+        insertRaw(eventsMongo.COLLECTION,event2.setUpdated(toDate(aPointInTime.plusHours(1))));
+        insertRaw(eventsMongo.COLLECTION,event3.setUpdated(toDate(aPointInTime.plusHours(2))));
+        insertRaw(eventsMongo.COLLECTION,event4.setUpdated(toDate(aPointInTime.plusHours(2).plusMinutes(35))));
 
-        List<MetadataNotification> allEvents = resource.getPastEventNotifications(null,null,null,null,null,null,aPointInTime.minusDays(100).format(NotificationsManagerResource.DATE_TIME_FORMATTER), null);
+
+        List<MetadataNotification> allEvents = resource.getPastEventNotifications(null,null,null,null,null,null,aPointInTime.minusDays(100).format(DateTimeFormatter.ISO_DATE_TIME), null);
         Assert.assertNotNull(allEvents);
         Assert.assertEquals(4, allEvents.size());
 
-        LocalDateTime lunchTime = LocalDateTime.parse("2019-01-01 12:00:00", NotificationsManagerResource.DATE_TIME_FORMATTER);
-        List<MetadataNotification> afterLunch = resource.getPastEventNotifications(null,null,null,null,null,null,lunchTime.format(NotificationsManagerResource.DATE_TIME_FORMATTER), null);
+        LocalDateTime lunchTime = LocalDateTime.parse("2019-01-01T12:00:00", DateTimeFormatter.ISO_DATE_TIME);
+        List<MetadataNotification> afterLunch = resource.getPastEventNotifications(null,null,null,null,null,null,lunchTime.format(DateTimeFormatter.ISO_DATE_TIME), null);
         Assert.assertNotNull(afterLunch);
         Assert.assertEquals(2, afterLunch.size());
+
     }
 
+    @Test
+    public void canRetrieveEventsByDateAsEpocMillis()
+    {
+
+        MetadataNotification event1 = new MetadataNotification("1", "test.com", "test", VERSION);
+        MetadataNotification event2 = new MetadataNotification("2", "test.com", "test1", VERSION);
+
+        eventsMongo.insert(event1);
+        insertRaw(eventsMongo.COLLECTION,event2.setUpdated(toDate(LocalDateTime.now().plusDays(1))));
+        Assert.assertEquals(2, eventsMongo.getAll().size());
+
+
+        List<MetadataNotification> found = resource.getPastEventNotifications(null,null,null,null,null,null,null, String.valueOf(System.currentTimeMillis()));
+        Assert.assertNotNull(found);
+        Assert.assertEquals(1, found.size());
+        Assert.assertTrue(found.stream().anyMatch(e -> e.getProjectId().equals("1")));
+
+    }
 }

--- a/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/guice/DepotStoreServerModule.java
+++ b/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/guice/DepotStoreServerModule.java
@@ -27,11 +27,9 @@ import org.finos.legend.depot.schedules.services.SchedulesFactory;
 import org.finos.legend.depot.store.admin.api.metrics.StorageMetrics;
 import org.finos.legend.depot.store.notifications.domain.QueueManagerConfiguration;
 import org.finos.legend.depot.store.server.configuration.DepotStoreServerConfiguration;
-
 import org.slf4j.Logger;
 
 import javax.inject.Named;
-import java.time.LocalDateTime;
 
 public class DepotStoreServerModule extends BaseModule<DepotStoreServerConfiguration>
 {
@@ -96,7 +94,7 @@ public class DepotStoreServerModule extends BaseModule<DepotStoreServerConfigura
     boolean scheduleStorageMetrics(SchedulesFactory schedulesFactory, StorageMetrics storageMetrics)
     {
         storageMetrics.init();
-        schedulesFactory.register("storage-metrics", LocalDateTime.now().plusMinutes(1), 60000L, true, storageMetrics::reportMetrics);
+        schedulesFactory.register("storage-metrics", 5 * SchedulesFactory.MINUTE, 5 * SchedulesFactory.MINUTE,storageMetrics::reportMetrics);
         return true;
     }
 

--- a/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/server/LegendDepotStoreServerJacksonJsonProvider.java
+++ b/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/server/LegendDepotStoreServerJacksonJsonProvider.java
@@ -21,17 +21,19 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 import javax.ws.rs.ext.ContextResolver;
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 public class LegendDepotStoreServerJacksonJsonProvider extends JacksonJsonProvider implements ContextResolver<ObjectMapper>
 {
-    public static final String SIMPLE_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    public static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     private final ObjectMapper objectMapper;
 
     public LegendDepotStoreServerJacksonJsonProvider()
     {
         objectMapper = new ObjectMapper()
-                .setDateFormat(new SimpleDateFormat(SIMPLE_DATE_FORMAT))
+                .setTimeZone(TimeZone.getDefault())
+                .setDateFormat(SIMPLE_DATE_FORMAT)
                 .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
     }
 

--- a/legend-depot-store-status/src/main/java/org/finos/legend/depot/store/status/services/StoreStatusService.java
+++ b/legend-depot-store-status/src/main/java/org/finos/legend/depot/store/status/services/StoreStatusService.java
@@ -16,15 +16,14 @@
 package org.finos.legend.depot.store.status.services;
 
 import org.finos.legend.depot.domain.version.VersionValidator;
-import org.finos.legend.depot.store.api.entities.Entities;
 import org.finos.legend.depot.store.admin.api.artifacts.RefreshStatusStore;
 import org.finos.legend.depot.store.admin.domain.artifacts.RefreshStatus;
+import org.finos.legend.depot.store.api.entities.Entities;
 import org.finos.legend.depot.store.api.projects.Projects;
 import org.finos.legend.depot.store.api.projects.ProjectsVersions;
 import org.finos.legend.depot.store.metrics.domain.VersionQuerySummary;
 import org.finos.legend.depot.store.metrics.services.QueryMetricsHandler;
 import org.finos.legend.depot.store.status.domain.StoreStatus;
-import org.finos.legend.sdlc.domain.model.version.VersionId;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -84,22 +83,20 @@ public class StoreStatusService
         versions.forEach(v ->
         {
             StoreStatus.VersionStatus versionStatus = new StoreStatus.VersionStatus(groupId, artifactId, v);
-            RefreshStatus updateStatus = statusService.get(groupId, artifactId, v).orElse(new RefreshStatus(groupId, artifactId, v));
+            Optional<RefreshStatus> updateStatus = statusService.get(groupId, artifactId, v);
             Optional<VersionQuerySummary> versionQueryCounter = queryMetricsHandler.getSummary(groupId, artifactId, v);
             if (versionQueryCounter.isPresent())
             {
                 versionStatus.queryCount = versionQueryCounter.get().getQueryCount();
                 versionStatus.lastQueried = versionQueryCounter.get().getLastQueryTime();
             }
-            versionStatus.lastUpdated = updateStatus.getLastRun();
-            versionStatus.updating = updateStatus.isRunning();
+            versionStatus.updating = updateStatus.isPresent();
             projectStatus.addVersionStatus(versionStatus);
         });
 
         StoreStatus.MasterRevisionStatus masterRevisionStatus = new StoreStatus.MasterRevisionStatus(groupId, artifactId);
-        RefreshStatus revisionsUpdateStatus = statusService.get(groupId, artifactId, VersionValidator.MASTER_SNAPSHOT).orElse(new RefreshStatus(groupId, artifactId, VersionValidator.MASTER_SNAPSHOT));;
-        masterRevisionStatus.lastUpdated = revisionsUpdateStatus.getLastRun();
-        masterRevisionStatus.updating = revisionsUpdateStatus.isRunning();
+        Optional<RefreshStatus> revisionsUpdateStatus = statusService.get(groupId, artifactId, VersionValidator.MASTER_SNAPSHOT);
+        masterRevisionStatus.updating = revisionsUpdateStatus.isPresent();
         projectStatus.setMasterRevisionStatus(masterRevisionStatus);
 
         return projectStatus;


### PR DESCRIPTION
Following changes has been made:

Artifact Refresh:
- simplified information kept for running refreshes
- new expires flag ensures refresh dont get stuck if process gets interrupted

Schedules:
- simplified information for schedule and fix disabling race conditions
- new expires flag ensure schedules dont get stuck on system crashes

Notifications:
- new histogram to track version completion times( ie time it takes for version to be available)
- new api to query processed notifications by date range in epoc millis( allows integration with other tools, ie grafana)

