### PR TITLE
Stop refreshing snapshot versions which are evicted

### DIFF
--- a/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/services/ArtifactsRefreshServiceImpl.java
+++ b/legend-depot-artifacts-refresh/src/main/java/org/finos/legend/depot/store/artifacts/services/ArtifactsRefreshServiceImpl.java
@@ -135,7 +135,8 @@ public class ArtifactsRefreshServiceImpl implements ArtifactsRefreshService
     {
         String parentEventId = ParentEvent.build(projectData.getGroupId(), projectData.getArtifactId(), ALL_SNAPSHOT, parentEvent);
         MetadataEventResponse response = new MetadataEventResponse();
-        List<String> snapshots = this.projects.getVersions(projectData.getGroupId(),projectData.getArtifactId(),true).stream().filter(v -> VersionValidator.isSnapshotVersion(v)).collect(Collectors.toList());
+        List<String> snapshots = this.projects.findSnapshotVersions(projectData.getGroupId(), projectData.getArtifactId())
+                .stream().filter(versionData -> !versionData.isEvicted()).map(versionData -> versionData.getVersionId()).collect(Collectors.toList());
         snapshots.forEach(v ->
         {
             String message = String.format("Executing: [%s-%s-%s], parentEventId :[%s], full/transitive :[%s/%s]", projectData.getGroupId(), projectData.getArtifactId(), v, parentEvent, fullUpdate, transitive);

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshService.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshService.java
@@ -297,6 +297,26 @@ public class TestArtifactsRefreshService extends TestStoreMongo
         Assert.assertTrue(statuses.isEmpty());
 
     }
+    
+    @Test
+    public void canRefreshAllVersionExceptForEvictedSnapshot()
+    {
+        MetadataEventResponse response = artifactsRefreshService.refreshAllVersionsForProject(TEST_GROUP_ID, TEST_ARTIFACT_ID, true, true,true,PARENT_EVENT_ID);
+        Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
+
+        Assert.assertEquals(3,notificationsQueueManager.getAllInQueue().size());
+        notificationsQueueManager.handleAll();
+
+        StoreProjectVersionData pv = new StoreProjectVersionData(TEST_GROUP_ID, TEST_ARTIFACT_ID, "dummy-SNAPSHOT");
+        pv.setEvicted(true);
+        projectsService.createOrUpdate(pv);
+
+        response = artifactsRefreshService.refreshAllVersionsForProject(TEST_GROUP_ID, TEST_ARTIFACT_ID, true, true,true,PARENT_EVENT_ID);
+        Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
+
+        Assert.assertEquals(3,notificationsQueueManager.getAllInQueue().size());
+        notificationsQueueManager.handleAll();
+    }
 
     @Test
     public void canRefreshAllVersionForProjectWithExcludedVersion()


### PR DESCRIPTION
evicted snapshot versions should not be refreshed