### PR TITLE
Support different default branch name for non-deprecated API's.

### DIFF
--- a/legend-depot-artifacts-purge/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsPurgeService.java
+++ b/legend-depot-artifacts-purge/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsPurgeService.java
@@ -28,6 +28,7 @@ import org.finos.legend.depot.services.api.projects.ManageProjectsService;
 import org.finos.legend.depot.services.entities.ManageEntitiesServiceImpl;
 import org.finos.legend.depot.services.generation.file.ManageFileGenerationsServiceImpl;
 import org.finos.legend.depot.services.projects.ManageProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.domain.metrics.VersionQueryMetric;
 import org.finos.legend.depot.store.api.entities.UpdateEntities;
 import org.finos.legend.depot.store.api.generation.file.UpdateFileGenerations;
@@ -60,7 +61,7 @@ import java.util.Optional;
 import java.util.Date;
 import java.util.Collections;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +77,7 @@ public class TestArtifactsPurgeService extends TestStoreMongo
     private final QueryMetricsMongo metrics = new QueryMetricsMongo(mongoProvider);
     private final QueryMetricsHandler metricHandler = new QueryMetricsHandler(metrics);
     private final Queue queue = mock(Queue.class);
-    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue);
+    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue, new ProjectsConfiguration("master"));
     protected UpdateEntities entitiesStore = new EntitiesMongo(mongoProvider);
     protected UpdateFileGenerations fileGenerationsStore = new FileGenerationsMongo(mongoProvider);
     protected ArtifactRepository repository = mock(ArtifactRepository.class);
@@ -155,7 +156,7 @@ public class TestArtifactsPurgeService extends TestStoreMongo
         Assert.assertNotNull(project);
         List<String> projectVersions = projectsService.getVersions(TEST_GROUP_ID, "test1");
         Assert.assertEquals(0, projectVersions.size());
-        Assert.assertEquals(1, entitiesStore.getEntities(TEST_GROUP_ID, "test1", MASTER_SNAPSHOT, false).size());
+        Assert.assertEquals(1, entitiesStore.getEntities(TEST_GROUP_ID, "test1", BRANCH_SNAPSHOT("master"), false).size());
 
         MetadataEventResponse response = purgeService.evictOldestProjectVersions(TEST_GROUP_ID,"test1",1);
         Assert.assertNotNull(response);
@@ -163,7 +164,7 @@ public class TestArtifactsPurgeService extends TestStoreMongo
         List<String> afterVersionsOrdered = projectsService.getVersions(TEST_GROUP_ID, "test1");
         Assert.assertEquals(0, afterVersionsOrdered.size());
 
-        Assert.assertEquals(1, entitiesStore.getEntities(TEST_GROUP_ID, "test1", MASTER_SNAPSHOT, false).size());
+        Assert.assertEquals(1, entitiesStore.getEntities(TEST_GROUP_ID, "test1", BRANCH_SNAPSHOT("master"), false).size());
     }
 
     @Test

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshService.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshService.java
@@ -32,6 +32,7 @@ import org.finos.legend.depot.services.api.projects.ManageProjectsService;
 import org.finos.legend.depot.services.entities.ManageEntitiesServiceImpl;
 import org.finos.legend.depot.services.generation.file.ManageFileGenerationsServiceImpl;
 import org.finos.legend.depot.services.projects.ManageProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.artifacts.ArtifactsFilesStore;
 import org.finos.legend.depot.store.admin.api.artifacts.RefreshStatusStore;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
@@ -73,7 +74,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.finos.legend.depot.store.artifacts.services.TestArtifactsRefreshServiceExceptionEscenarios.PARENT_EVENT_ID;
 import static org.mockito.Mockito.mock;
 
@@ -90,7 +91,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     protected UpdateProjectsVersions projectsVersionsStore = new ProjectsVersionsMongo(mongoProvider);
     private final QueryMetricsStore metrics = mock(QueryMetricsStore.class);
     protected Queue queue = new NotificationsQueueMongo(mongoProvider);
-    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(projectsVersionsStore,projectsStore,metrics,queue);
+    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(projectsVersionsStore,projectsStore,metrics,queue,new ProjectsConfiguration("master"));
     protected UpdateEntities entitiesStore = new EntitiesMongo(mongoProvider);
     protected List<String> properties = Arrays.asList("[a-zA-Z0-9]+.version");
     protected List<String> manifestProperties = Arrays.asList("commit-[a-zA-Z0-9]+", "release-[a-zA-Z0-9]+");
@@ -120,10 +121,10 @@ public class TestArtifactsRefreshService extends TestStoreMongo
         ProjectArtifactHandlerFactory.registerArtifactHandler(ArtifactType.VERSIONED_ENTITIES, new VersionedEntitiesHandlerImpl(new ManageEntitiesServiceImpl(entitiesStore, projectsService), versionedEntityProvider));
 
         projectsVersionsStore.createOrUpdate(new StoreProjectVersionData(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, "2.0.0"));
-        projectsVersionsStore.createOrUpdate(new StoreProjectVersionData(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, MASTER_SNAPSHOT));
+        projectsVersionsStore.createOrUpdate(new StoreProjectVersionData(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, BRANCH_SNAPSHOT("master")));
         projectsVersionsStore.createOrUpdate(new StoreProjectVersionData(TEST_GROUP_ID, TEST_ARTIFACT_ID,"2.3.3"));
         projectsVersionsStore.createOrUpdate(new StoreProjectVersionData(TEST_GROUP_ID, TEST_ARTIFACT_ID, "1.0.0"));
-        projectsVersionsStore.createOrUpdate(new StoreProjectVersionData(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT));
+        projectsVersionsStore.createOrUpdate(new StoreProjectVersionData(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master")));
 
         projectsStore.createOrUpdate(new StoreProjectData(PROJECT_B, TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID));
         projectsStore.createOrUpdate(new StoreProjectData(PROJECT_A, TEST_GROUP_ID, TEST_ARTIFACT_ID));
@@ -141,19 +142,19 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     public void canUpdateCreateVersion()
     {
 
-        Assert.assertTrue(entitiesStore.getEntities(TEST_GROUP_ID, "art101", MASTER_SNAPSHOT, false).isEmpty());
+        Assert.assertTrue(entitiesStore.getEntities(TEST_GROUP_ID, "art101", BRANCH_SNAPSHOT("master"), false).isEmpty());
         Assert.assertEquals(0, projectsVersionsStore.find(TEST_GROUP_ID, "art101").size());
         StoreProjectData projectData = projectsStore.find(TEST_GROUP_ID, "art101").get();
-        List<File> files = repository.findFiles(ArtifactType.ENTITIES, projectData.getGroupId(), projectData.getArtifactId(), MASTER_SNAPSHOT);
+        List<File> files = repository.findFiles(ArtifactType.ENTITIES, projectData.getGroupId(), projectData.getArtifactId(), BRANCH_SNAPSHOT("master"));
         Assert.assertNotNull(files);
         Assert.assertEquals(1,files.size());
-        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(TEST_GROUP_ID, "art101",MASTER_SNAPSHOT,true,true,PARENT_EVENT_ID);
+        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(TEST_GROUP_ID, "art101",BRANCH_SNAPSHOT("master"),true,true,PARENT_EVENT_ID);
         Assert.assertNotNull(response);
         notificationsQueueManager.handleAll();
-        Assert.assertTrue(refreshStatusStore.find(TEST_GROUP_ID, "art101", MASTER_SNAPSHOT).isEmpty());
+        Assert.assertTrue(refreshStatusStore.find(TEST_GROUP_ID, "art101", BRANCH_SNAPSHOT("master")).isEmpty());
         Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
-        Assert.assertEquals(0, projectsVersionsStore.find(TEST_GROUP_ID, "art101").stream().filter(x -> !x.getVersionId().equals(MASTER_SNAPSHOT)).collect(Collectors.toList()).size());
-        List<Entity> entities = entitiesStore.getEntities(TEST_GROUP_ID, "art101", MASTER_SNAPSHOT, false);
+        Assert.assertEquals(0, projectsVersionsStore.find(TEST_GROUP_ID, "art101").stream().filter(x -> !x.getVersionId().equals(BRANCH_SNAPSHOT("master"))).collect(Collectors.toList()).size());
+        List<Entity> entities = entitiesStore.getEntities(TEST_GROUP_ID, "art101", BRANCH_SNAPSHOT("master"), false);
         Assert.assertNotNull(entities);
         Assert.assertEquals(9, entities.size());
         Assert.assertEquals(0,notificationsQueueManager.getAllInQueue().size());
@@ -163,8 +164,8 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     public void canUpdateVersionForNewDLCProjectStyle()
     {
         StoreProjectData projectData = projectsStore.find(TEST_GROUP_ID, "art101").get();
-        repository.findFiles(ArtifactType.ENTITIES, projectData.getGroupId(), projectData.getArtifactId(), MASTER_SNAPSHOT);
-        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(TEST_GROUP_ID, "art101",MASTER_SNAPSHOT,false,true,PARENT_EVENT_ID);
+        repository.findFiles(ArtifactType.ENTITIES, projectData.getGroupId(), projectData.getArtifactId(), BRANCH_SNAPSHOT("master"));
+        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(TEST_GROUP_ID, "art101",BRANCH_SNAPSHOT("master"),false,true,PARENT_EVENT_ID);
         notificationsQueueManager.handleAll();
         Assert.assertNotNull(response);
         Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
@@ -174,12 +175,12 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     public void canRefreshArtifactWithProjectProperties()
     {
         StoreProjectData projectData = projectsStore.find(TEST_GROUP_ID, "art101").get();
-        repository.findFiles(ArtifactType.ENTITIES, projectData.getGroupId(), projectData.getArtifactId(), MASTER_SNAPSHOT);
-        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(projectData.getGroupId(), projectData.getArtifactId(), MASTER_SNAPSHOT,false,true,PARENT_EVENT_ID);
+        repository.findFiles(ArtifactType.ENTITIES, projectData.getGroupId(), projectData.getArtifactId(), BRANCH_SNAPSHOT("master"));
+        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(projectData.getGroupId(), projectData.getArtifactId(), BRANCH_SNAPSHOT("master"),false,true,PARENT_EVENT_ID);
         notificationsQueueManager.handleAll();
         Assert.assertNotNull(response);
         Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
-        Optional<StoreProjectVersionData> updatedProjectData = projectsVersionsStore.find(TEST_GROUP_ID, "art101", MASTER_SNAPSHOT);
+        Optional<StoreProjectVersionData> updatedProjectData = projectsVersionsStore.find(TEST_GROUP_ID, "art101", BRANCH_SNAPSHOT("master"));
         Assert.assertTrue(updatedProjectData.isPresent());
         Assert.assertEquals("0.0.0", updatedProjectData.get().getVersionData().getProperties().get(0).getValue());
 
@@ -193,9 +194,9 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     public void canUpdateCreateMasterRevision()
     {
         StoreProjectData projectData = projectsStore.find(TEST_GROUP_ID, "art101").get();
-        List<File> files = repository.findFiles(ArtifactType.ENTITIES, projectData.getGroupId(), projectData.getArtifactId(), MASTER_SNAPSHOT);
+        List<File> files = repository.findFiles(ArtifactType.ENTITIES, projectData.getGroupId(), projectData.getArtifactId(), BRANCH_SNAPSHOT("master"));
         Assert.assertNotNull(files);
-        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(projectData.getGroupId(), projectData.getArtifactId(), MASTER_SNAPSHOT,true,true,PARENT_EVENT_ID);
+        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(projectData.getGroupId(), projectData.getArtifactId(), BRANCH_SNAPSHOT("master"),true,true,PARENT_EVENT_ID);
         Assert.assertNotNull(response);
         Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
         Assert.assertEquals(1,notificationsQueueManager.getAllInQueue().size());
@@ -332,7 +333,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
 
         Assert.assertEquals(1,notificationsQueueManager.getAllInQueue().size());
 
-        Assert.assertEquals(MASTER_SNAPSHOT, notificationsQueueManager.getAllInQueue().get(0).getVersionId());
+        Assert.assertEquals(BRANCH_SNAPSHOT("master"), notificationsQueueManager.getAllInQueue().get(0).getVersionId());
         notificationsQueueManager.handleAll();
 
     }
@@ -387,7 +388,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
 
         MetadataEventResponse partialUpdate = artifactsRefreshService.refreshAllVersionsForAllProjects(false,false,true,PARENT_EVENT_ID);
         Assert.assertEquals(3,notificationsQueueManager.getAllInQueue().size());
-        notificationsQueueManager.getAllInQueue().stream().allMatch(notification -> MASTER_SNAPSHOT.equals(notification.getVersionId()));
+        notificationsQueueManager.getAllInQueue().stream().allMatch(notification -> BRANCH_SNAPSHOT("master").equals(notification.getVersionId()));
         notificationsQueueManager.handleAll();
     }
 
@@ -395,20 +396,20 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     public void canRefreshProjectMasterVersion()
     {
 
-        Assert.assertEquals(0, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT).size());
+        Assert.assertEquals(0, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master")).size());
 
         Assert.assertEquals(0, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, "1.0.0").size());
 
-        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT,true,PARENT_EVENT_ID);
+        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master"),true,PARENT_EVENT_ID);
         Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
         Assert.assertEquals(1,notificationsQueueManager.getAllInQueue().size());
         notificationsQueueManager.handleAll();
 
-        Assert.assertEquals(18, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT).size());
+        Assert.assertEquals(18, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master")).size());
 
         Assert.assertEquals(2, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, "1.0.0").size());
 
-        ProjectVersionData projectVersionData = projectsVersionsStore.find(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT).get().getVersionData();
+        ProjectVersionData projectVersionData = projectsVersionsStore.find(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master")).get().getVersionData();
         List<ProjectVersion> dependencies = projectVersionData.getDependencies();
         Assert.assertEquals(2, dependencies.size());
 
@@ -428,15 +429,15 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     public void canRefreshProjectMasterVersionWithAllDependenciesTransitively()
     {
 
-        Assert.assertEquals(0, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT).size());
+        Assert.assertEquals(0, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master")).size());
         Assert.assertEquals(0, entitiesStore.getAllEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, "1.0.0").size());
         Assert.assertEquals(0, entitiesStore.getAllEntities(TEST_GROUP_ID, "art101", "2.0.0").size());
 
-        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT,true,PARENT_EVENT_ID);
+        MetadataEventResponse response = artifactsRefreshService.refreshVersionForProject(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master"),true,PARENT_EVENT_ID);
         Assert.assertEquals(MetadataEventStatus.SUCCESS, response.getStatus());
         Assert.assertEquals(1,notificationsQueueManager.getAllInQueue().size());
         notificationsQueueManager.handle();
-        List<ProjectVersion> dependencies = projectsVersionsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID, MASTER_SNAPSHOT).get().getVersionData().getDependencies();
+        List<ProjectVersion> dependencies = projectsVersionsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master")).get().getVersionData().getDependencies();
         Assert.assertEquals(2, dependencies.size());
 
         Assert.assertEquals(2,notificationsQueueManager.getAllInQueue().size());
@@ -465,16 +466,16 @@ public class TestArtifactsRefreshService extends TestStoreMongo
     @Test
     public void canLoadEntitiesWithVersionInPackageName()
     {
-        MetadataEventResponse partialUpdate = versionHandler.handleEvent(new MetadataNotification("prod-1",TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID,MASTER_SNAPSHOT,false,false,PARENT_EVENT_ID));
+        MetadataEventResponse partialUpdate = versionHandler.handleEvent(new MetadataNotification("prod-1",TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID,BRANCH_SNAPSHOT("master"),false,false,PARENT_EVENT_ID));
         Assert.assertNotNull(partialUpdate);
-        Assert.assertEquals(4, entitiesStore.getStoredEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, MASTER_SNAPSHOT).size());
+        Assert.assertEquals(4, entitiesStore.getStoredEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, BRANCH_SNAPSHOT("master")).size());
 
-        MetadataEventResponse fullUpdate = versionHandler.handleEvent(new MetadataNotification("prod-1",TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID,MASTER_SNAPSHOT,true,false,PARENT_EVENT_ID));
+        MetadataEventResponse fullUpdate = versionHandler.handleEvent(new MetadataNotification("prod-1",TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID,BRANCH_SNAPSHOT("master"),true,false,PARENT_EVENT_ID));
         Assert.assertNotNull(fullUpdate);
 
-        Assert.assertEquals(4, entitiesStore.getStoredEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, MASTER_SNAPSHOT).size());
-        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, MASTER_SNAPSHOT,false).size());
-        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, MASTER_SNAPSHOT,true).size());
+        Assert.assertEquals(4, entitiesStore.getStoredEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, BRANCH_SNAPSHOT("master")).size());
+        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, BRANCH_SNAPSHOT("master"),false).size());
+        Assert.assertEquals(2, entitiesStore.getEntities(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, BRANCH_SNAPSHOT("master"),true).size());
 
     }
 
@@ -512,7 +513,7 @@ public class TestArtifactsRefreshService extends TestStoreMongo
         notificationsQueueManager.handleAll();
         Assert.assertEquals(docsBefore,entitiesStore.getAllStoredEntities().size());
         Assert.assertTrue(projectsVersionsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID,versionId).isPresent());
-        Assert.assertEquals(3,projectsVersionsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID).stream().filter(x -> !x.getVersionId().equals(MASTER_SNAPSHOT)).collect(Collectors.toList()).size());
+        Assert.assertEquals(3,projectsVersionsStore.find(TEST_GROUP_ID,TEST_ARTIFACT_ID).stream().filter(x -> !x.getVersionId().equals(BRANCH_SNAPSHOT("master"))).collect(Collectors.toList()).size());
         Assert.assertEquals(0,notificationsQueueManager.getAllInQueue().size());
     }
 

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceExceptionEscenarios.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceExceptionEscenarios.java
@@ -28,6 +28,7 @@ import org.finos.legend.depot.services.api.projects.ManageProjectsService;
 import org.finos.legend.depot.services.entities.ManageEntitiesServiceImpl;
 import org.finos.legend.depot.services.generation.file.ManageFileGenerationsServiceImpl;
 import org.finos.legend.depot.services.projects.ManageProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.artifacts.ArtifactsFilesStore;
 import org.finos.legend.depot.store.admin.api.artifacts.RefreshStatusStore;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
@@ -84,7 +85,7 @@ public class TestArtifactsRefreshServiceExceptionEscenarios extends TestStoreMon
     protected UpdateProjectsVersions mongoProjectsVersions = mock(UpdateProjectsVersions.class);
     private final QueryMetricsStore metrics = mock(QueryMetricsStore.class);
     protected Queue queue = new NotificationsQueueMongo(mongoProvider);
-    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(mongoProjectsVersions,mongoProjects,metrics,queue);
+    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(mongoProjectsVersions,mongoProjects,metrics,queue,new ProjectsConfiguration("master"));
     protected UpdateEntities mongoEntities = mock(UpdateEntities.class);
     protected ManageEntitiesService entitiesService = new ManageEntitiesServiceImpl(mongoEntities,projectsService);
     protected UpdateFileGenerations mongoGenerations = mock(UpdateFileGenerations.class);

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceWithMocks.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestArtifactsRefreshServiceWithMocks.java
@@ -27,6 +27,7 @@ import org.finos.legend.depot.services.api.projects.ManageProjectsService;
 import org.finos.legend.depot.services.entities.ManageEntitiesServiceImpl;
 import org.finos.legend.depot.services.generation.file.ManageFileGenerationsServiceImpl;
 import org.finos.legend.depot.services.projects.ManageProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.artifacts.ArtifactsFilesStore;
 import org.finos.legend.depot.store.admin.api.artifacts.RefreshStatusStore;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
@@ -56,7 +57,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -82,7 +83,7 @@ public class TestArtifactsRefreshServiceWithMocks extends TestStoreMongo
     protected UpdateProjectsVersions mongoProjectsVersions = mock(UpdateProjectsVersions.class);
     private final QueryMetricsStore metrics = mock(QueryMetricsStore.class);
     protected Queue queue = new NotificationsQueueMongo(mongoProvider);
-    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(mongoProjectsVersions,mongoProjects, metrics, queue);
+    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(mongoProjectsVersions,mongoProjects, metrics, queue, new ProjectsConfiguration("master"));
     protected UpdateEntities mongoEntities = mock(UpdateEntities.class);
     protected ManageEntitiesService entitiesService = new ManageEntitiesServiceImpl(mongoEntities,projectsService);
     protected UpdateFileGenerations mongoGenerations = mock(UpdateFileGenerations.class);
@@ -106,8 +107,8 @@ public class TestArtifactsRefreshServiceWithMocks extends TestStoreMongo
         when(mongoProjects.getAll()).thenReturn(projects);
         when(mongoProjects.find(TEST_GROUP_ID,TEST_ARTIFACT_ID)).thenReturn(Optional.of(new StoreProjectData(PROJECT_A, TEST_GROUP_ID, TEST_ARTIFACT_ID)));
         when(mongoProjects.find(TEST_GROUP_ID,TEST_DEPENDENCIES_ARTIFACT_ID)).thenReturn(Optional.of(new StoreProjectData(PROJECT_B,TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID)));
-        when(mongoProjectsVersions.find(TEST_GROUP_ID, TEST_ARTIFACT_ID,MASTER_SNAPSHOT)).thenReturn(Optional.of(new StoreProjectVersionData(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT)));
-        when(mongoProjectsVersions.find(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID,MASTER_SNAPSHOT)).thenReturn(Optional.of(new StoreProjectVersionData(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, MASTER_SNAPSHOT)));
+        when(mongoProjectsVersions.find(TEST_GROUP_ID, TEST_ARTIFACT_ID,BRANCH_SNAPSHOT("master"))).thenReturn(Optional.of(new StoreProjectVersionData(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master"))));
+        when(mongoProjectsVersions.find(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID,BRANCH_SNAPSHOT("master"))).thenReturn(Optional.of(new StoreProjectVersionData(TEST_GROUP_ID, TEST_DEPENDENCIES_ARTIFACT_ID, BRANCH_SNAPSHOT("master"))));
         when(repository.findVersions(TEST_GROUP_ID,TEST_ARTIFACT_ID)).thenReturn(Arrays.asList(VersionId.parseVersionId("1.0.0"), VersionId.parseVersionId("2.0.0")));
         when(repository.findVersions(TEST_GROUP_ID,TEST_DEPENDENCIES_ARTIFACT_ID)).thenReturn(Arrays.asList(VersionId.parseVersionId("1.0.0")));
         when(repository.findVersions(TEST_GROUP_ID,"c")).thenReturn(Arrays.asList(VersionId.parseVersionId("1.0.0")));

--- a/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestDependencyManager.java
+++ b/legend-depot-artifacts-refresh/src/test/java/org/finos/legend/depot/store/artifacts/services/TestDependencyManager.java
@@ -22,6 +22,7 @@ import org.finos.legend.depot.domain.project.ProjectVersion;
 import org.finos.legend.depot.domain.project.StoreProjectVersionData;
 import org.finos.legend.depot.services.api.projects.ManageProjectsService;
 import org.finos.legend.depot.services.projects.ManageProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.artifacts.ArtifactsFilesStore;
 import org.finos.legend.depot.store.admin.api.artifacts.RefreshStatusStore;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
@@ -50,7 +51,7 @@ public class TestDependencyManager extends TestStoreMongo
     protected UpdateProjectsVersions projectsVersionsStore = new ProjectsVersionsMongo(mongoProvider);
     private final QueryMetricsStore metrics = mock(QueryMetricsStore.class);
     protected Queue queue = new NotificationsQueueMongo(mongoProvider);
-    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(projectsVersionsStore,projectsStore,metrics,queue);
+    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(projectsVersionsStore,projectsStore,metrics,queue,new ProjectsConfiguration("master"));
     protected ArtifactRepository repository = mock(TestMavenArtifactsRepository.class);
     protected RepositoryServices repositoryServices = new RepositoryServices(repository,projectsService);
     protected ArtifactsFilesStore artifacts = new ArtifactsFilesMongo(mongoProvider);

--- a/legend-depot-artifacts-repository-maven-impl/src/test/java/org/finos/legend/depot/artifacts/repository/maven/impl/TestMavenArtifactsRepository.java
+++ b/legend-depot-artifacts-repository-maven-impl/src/test/java/org/finos/legend/depot/artifacts/repository/maven/impl/TestMavenArtifactsRepository.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 public class TestMavenArtifactsRepository extends MavenArtifactRepository implements ArtifactRepository
 {
@@ -41,9 +41,9 @@ public class TestMavenArtifactsRepository extends MavenArtifactRepository implem
 
     static
     {
-        TESTING_VERSIONS.put("examples.metadata.test", Arrays.asList(MASTER_SNAPSHOT, "2.0.0", "1.0.0"));
-        TESTING_VERSIONS.put("examples.metadata.test-dependencies", Arrays.asList(MASTER_SNAPSHOT,"1.0.0"));
-        TESTING_VERSIONS.put("examples.metadata.art101", Arrays.asList(MASTER_SNAPSHOT));
+        TESTING_VERSIONS.put("examples.metadata.test", Arrays.asList(BRANCH_SNAPSHOT("master"), "2.0.0", "1.0.0"));
+        TESTING_VERSIONS.put("examples.metadata.test-dependencies", Arrays.asList(BRANCH_SNAPSHOT("master"),"1.0.0"));
+        TESTING_VERSIONS.put("examples.metadata.art101", Arrays.asList(BRANCH_SNAPSHOT("master")));
     }
 
     public TestMavenArtifactsRepository()
@@ -54,7 +54,7 @@ public class TestMavenArtifactsRepository extends MavenArtifactRepository implem
     @Override
     public List<VersionId> findVersions(String group, String artifact)
     {
-        return TESTING_VERSIONS.getOrDefault(group + DOT + artifact, Collections.emptyList()).stream().filter(v -> !v.equals(MASTER_SNAPSHOT)).map(v -> VersionId.parseVersionId(v)).collect(Collectors.toList());
+        return TESTING_VERSIONS.getOrDefault(group + DOT + artifact, Collections.emptyList()).stream().filter(v -> !v.equals(BRANCH_SNAPSHOT("master"))).map(v -> VersionId.parseVersionId(v)).collect(Collectors.toList());
     }
 
     @Override

--- a/legend-depot-core-http/pom.xml
+++ b/legend-depot-core-http/pom.xml
@@ -88,6 +88,10 @@
             <groupId>org.finos.legend.sdlc</groupId>
             <artifactId>legend-sdlc-server-shared</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.depot</groupId>
+            <artifactId>legend-depot-core-services</artifactId>
+        </dependency>
         <!-- SDLC -->
     </dependencies>
 </project>

--- a/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/ServersConfiguration.java
+++ b/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/ServersConfiguration.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.api.StorageConfiguration;
 import org.finos.legend.depot.tracing.configuration.OpenTracingConfiguration;
 import org.finos.legend.depot.tracing.configuration.PrometheusConfiguration;
@@ -57,6 +58,10 @@ public class ServersConfiguration extends Configuration
     @JsonProperty("storage")
     private StorageConfiguration storage;
 
+    @NotNull
+    @JsonProperty("projects")
+    private ProjectsConfiguration projects;
+
     @JsonProperty("openTracing")
     private OpenTracingConfiguration openTracingConfiguration;
 
@@ -74,6 +79,11 @@ public class ServersConfiguration extends Configuration
     public StorageConfiguration getStorageConfiguration()
     {
         return storage;
+    }
+
+    public ProjectsConfiguration getProjectsConfiguration()
+    {
+        return projects;
     }
 
     public void setStorage(StorageConfiguration storage)

--- a/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/guice/BaseModule.java
+++ b/legend-depot-core-http/src/main/java/org/finos/legend/depot/core/http/guice/BaseModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Provides;
 import com.google.inject.servlet.RequestScoped;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import org.finos.legend.depot.core.http.ServersConfiguration;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.api.StorageConfiguration;
 import org.finos.legend.depot.tracing.configuration.OpenTracingConfiguration;
 import org.finos.legend.depot.tracing.configuration.PrometheusConfiguration;
@@ -34,6 +35,7 @@ public abstract class BaseModule<T extends ServersConfiguration> extends Dropwiz
     @Override
     public void configure(Binder binder)
     {
+        binder.bind(ProjectsConfiguration.class).toProvider(this::getProjectsConfig);
         binder.bind(StorageConfiguration.class).toProvider(this::getStorageConfig);
         binder.bind(OpenTracingConfiguration.class).toProvider(this::getTracingConfig);
         binder.bind(PrometheusConfiguration.class).toProvider(this::getPrometheusConfig);
@@ -58,6 +60,11 @@ public abstract class BaseModule<T extends ServersConfiguration> extends Dropwiz
     private StorageConfiguration getStorageConfig()
     {
         return getConfiguration().getStorageConfiguration();
+    }
+
+    private ProjectsConfiguration getProjectsConfig()
+    {
+        return getConfiguration().getProjectsConfiguration() != null ? getConfiguration().getProjectsConfiguration() : new ProjectsConfiguration("master");
     }
 
     private OpenTracingConfiguration getTracingConfig()

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/projects/ManageProjectsServiceImpl.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/projects/ManageProjectsServiceImpl.java
@@ -19,6 +19,7 @@ import org.finos.legend.depot.domain.api.MetadataEventResponse;
 import org.finos.legend.depot.domain.project.StoreProjectData;
 import org.finos.legend.depot.domain.project.StoreProjectVersionData;
 import org.finos.legend.depot.services.api.projects.ManageProjectsService;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
 import org.finos.legend.depot.store.api.projects.UpdateProjects;
 import org.finos.legend.depot.store.api.projects.UpdateProjectsVersions;
@@ -34,9 +35,9 @@ public class ManageProjectsServiceImpl extends ProjectsServiceImpl implements Ma
     private final UpdateProjects projects;
 
     @Inject
-    public ManageProjectsServiceImpl(UpdateProjectsVersions projectsVersions, UpdateProjects projects, QueryMetricsStore metrics, Queue queue)
+    public ManageProjectsServiceImpl(UpdateProjectsVersions projectsVersions, UpdateProjects projects, QueryMetricsStore metrics, Queue queue, ProjectsConfiguration configuration)
     {
-        super(projectsVersions,projects, metrics, queue);
+        super(projectsVersions,projects, metrics, queue, configuration);
         this.projects = projects;
         this.projectsVersions = projectsVersions;
     }

--- a/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/projects/configuration/ProjectsConfiguration.java
+++ b/legend-depot-core-services/src/main/java/org/finos/legend/depot/services/projects/configuration/ProjectsConfiguration.java
@@ -1,4 +1,4 @@
-//  Copyright 2021 Goldman Sachs
+//  Copyright 2023 Goldman Sachs
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -13,22 +13,27 @@
 //  limitations under the License.
 //
 
-package org.finos.legend.depot.domain.version;
+package org.finos.legend.depot.services.projects.configuration;
 
-import org.junit.Assert;
-import org.junit.Test;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
+import javax.validation.constraints.NotNull;
 
-public class TestVersionValidator
+public class ProjectsConfiguration
 {
-    @Test
-    public void testVersionsAreCorrect()
+    @NotNull
+    @JsonProperty
+    private final String defaultBranch;
+
+    @JsonCreator
+    public ProjectsConfiguration(@JsonProperty("defaultBranch") String defaultBranch)
     {
-        Assert.assertTrue(VersionValidator.isValid("1.1.1"));
-        Assert.assertTrue(VersionValidator.isValid(BRANCH_SNAPSHOT("master")));
-        Assert.assertFalse(VersionValidator.isValid("jkwhfkjasf-jhdfjks"));
-        Assert.assertTrue(VersionValidator.isValid("my-SNAPSHOT"));
+        this.defaultBranch = defaultBranch;
     }
 
+    public String getDefaultBranch()
+    {
+        return defaultBranch;
+    }
 }

--- a/legend-depot-core-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
+++ b/legend-depot-core-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
@@ -26,6 +26,7 @@ import org.finos.legend.depot.domain.project.dependencies.VersionDependencyRepor
 import org.finos.legend.depot.services.TestBaseServices;
 import org.finos.legend.depot.services.api.entities.ManageEntitiesService;
 import org.finos.legend.depot.services.projects.ProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
 import org.finos.legend.depot.store.notifications.queue.api.Queue;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
@@ -39,13 +40,13 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import static org.mockito.Mockito.mock;
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 public class TestEntitiesService extends TestBaseServices
 {
     private final QueryMetricsStore metrics = mock(QueryMetricsStore.class);
     private final Queue queue = mock(Queue.class);
-    protected ManageEntitiesService entitiesService = new ManageEntitiesServiceImpl(entitiesStore, new ProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue));
+    protected ManageEntitiesService entitiesService = new ManageEntitiesServiceImpl(entitiesStore, new ProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue, new ProjectsConfiguration("master")));
 
     @Before
     public void setUpData()
@@ -197,8 +198,8 @@ public class TestEntitiesService extends TestBaseServices
     @Test
     public void canQueryEntitiesWithHeadVersionAlias()
     {
-        projectsVersionsStore.createOrUpdate(new StoreProjectVersionData("examples.metadata","test", MASTER_SNAPSHOT));
-        loadEntities("PROD-A", MASTER_SNAPSHOT);
+        projectsVersionsStore.createOrUpdate(new StoreProjectVersionData("examples.metadata","test", BRANCH_SNAPSHOT("master")));
+        loadEntities("PROD-A", BRANCH_SNAPSHOT("master"));
 
         String pkgName = "examples::metadata::test::v2_3_1::examples::metadata::test";
 

--- a/legend-depot-core-services/src/test/java/org/finos/legend/depot/services/projects/TestProjectsService.java
+++ b/legend-depot-core-services/src/test/java/org/finos/legend/depot/services/projects/TestProjectsService.java
@@ -28,6 +28,7 @@ import org.finos.legend.depot.domain.project.dependencies.ProjectDependencyWithP
 import org.finos.legend.depot.domain.project.dependencies.VersionDependencyReport;
 import org.finos.legend.depot.services.TestBaseServices;
 import org.finos.legend.depot.services.api.projects.ManageProjectsService;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
 import org.finos.legend.depot.store.notifications.queue.api.Queue;
 import org.finos.legend.depot.store.notifications.queue.store.mongo.NotificationsQueueMongo;
@@ -42,14 +43,14 @@ import java.util.Collections;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.mockito.Mockito.mock;
 
 public class TestProjectsService extends TestBaseServices
 {
     private final QueryMetricsStore metrics = mock(QueryMetricsStore.class);
     private final Queue queue = new NotificationsQueueMongo(mongoProvider);
-    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue);
+    protected ManageProjectsService projectsService = new ManageProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue, new ProjectsConfiguration("master"));
 
     @Before
     public void setUpData()
@@ -210,7 +211,7 @@ public class TestProjectsService extends TestBaseServices
         Assert.assertFalse(dependencyList2.isEmpty());
         Assert.assertEquals(2, dependencyList2.size());
         Assert.assertTrue(dependencyList2.contains(new ProjectDependencyWithPlatformVersions("examples.metadata", "test", "2.3.1", new ProjectVersion("examples.metadata", "test-dependencies", "1.0.0"), Collections.emptyList())));
-        Assert.assertTrue(dependencyList2.contains(new ProjectDependencyWithPlatformVersions("examples.metadata", "test", MASTER_SNAPSHOT, new ProjectVersion("examples.metadata", "test-dependencies", "1.0.0"), Collections.emptyList())));
+        Assert.assertTrue(dependencyList2.contains(new ProjectDependencyWithPlatformVersions("examples.metadata", "test", BRANCH_SNAPSHOT("master"), new ProjectVersion("examples.metadata", "test-dependencies", "1.0.0"), Collections.emptyList())));
 
         List<ProjectDependencyWithPlatformVersions> dependencyList3 = projectsService.getDependentProjects("example.services.test", "test", "1.0.0");
         Assert.assertFalse(dependencyList3.isEmpty());
@@ -265,7 +266,7 @@ public class TestProjectsService extends TestBaseServices
         Assert.assertFalse(dependencyList2.isEmpty());
         Assert.assertEquals(2, dependencyList2.size());
         Assert.assertTrue(dependencyList2.contains(new ProjectDependencyWithPlatformVersions("examples.metadata", "test", "2.3.1", new ProjectVersion("examples.metadata", "test-dependencies", "1.0.0"), Collections.emptyList())));
-        Assert.assertTrue(dependencyList2.contains(new ProjectDependencyWithPlatformVersions("examples.metadata", "test", MASTER_SNAPSHOT, new ProjectVersion("examples.metadata", "test-dependencies", "1.0.0"), Collections.emptyList())));
+        Assert.assertTrue(dependencyList2.contains(new ProjectDependencyWithPlatformVersions("examples.metadata", "test", BRANCH_SNAPSHOT("master"), new ProjectVersion("examples.metadata", "test-dependencies", "1.0.0"), Collections.emptyList())));
 
         StoreProjectVersionData projectData = projectsService.find("examples.metadata", "test-dependencies", "1.0.0").get();
         projectData.getVersionData().addDependency(new ProjectVersion("example.services.test", "test", "2.0.0"));
@@ -295,7 +296,7 @@ public class TestProjectsService extends TestBaseServices
 
         Assert.assertFalse(projectsService.find("dont","exist","latest").isPresent());
 
-        StoreProjectVersionData noVersions = new StoreProjectVersionData("noversion","examples",MASTER_SNAPSHOT);
+        StoreProjectVersionData noVersions = new StoreProjectVersionData("noversion","examples",BRANCH_SNAPSHOT("master"));
         projectsService.createOrUpdate(noVersions);
 
         Assert.assertFalse(projectsService.find("noversion","examples", VersionAlias.LATEST.getName()).isPresent());
@@ -332,7 +333,7 @@ public class TestProjectsService extends TestBaseServices
     {
         Assert.assertEquals(2, projectsService.getVersions("examples.metadata","test", false).size());
         Assert.assertEquals(3, projectsService.getVersions("examples.metadata","test", true).size());
-        projectsService.excludeProjectVersion("examples.metadata","test",MASTER_SNAPSHOT,"test");
+        projectsService.excludeProjectVersion("examples.metadata","test",BRANCH_SNAPSHOT("master"),"test");
         Assert.assertEquals(2, projectsService.getVersions("examples.metadata","test", true).size());
         projectsService.excludeProjectVersion("examples.metadata","test","2.3.1","test");
         Assert.assertEquals(1, projectsService.getVersions("examples.metadata","test", true).size());
@@ -360,7 +361,7 @@ public class TestProjectsService extends TestBaseServices
     @Test
     public void testCanGetMasterSnapshotVersionIdUsingAlias()
     {
-        Assert.assertEquals(MASTER_SNAPSHOT, projectsService.resolveAliasesAndCheckVersionExists("examples.metadata","test", "head"));
+        Assert.assertEquals(BRANCH_SNAPSHOT("master"), projectsService.resolveAliasesAndCheckVersionExists("examples.metadata","test", "head"));
     }
 
     @Test

--- a/legend-depot-model/src/main/java/org/finos/legend/depot/domain/project/StoreProjectData.java
+++ b/legend-depot-model/src/main/java/org/finos/legend/depot/domain/project/StoreProjectData.java
@@ -26,6 +26,8 @@ import org.finos.legend.depot.domain.CoordinateData;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StoreProjectData extends CoordinateData implements HasIdentifier
 {
+    @JsonProperty
+    private String defaultBranch;
 
     @JsonProperty
     private String projectId;
@@ -35,12 +37,27 @@ public class StoreProjectData extends CoordinateData implements HasIdentifier
         super();
     }
 
+    public StoreProjectData(String projectId, String groupId, String artifactId, String defaultBranch)
+    {
+        this(projectId, groupId, artifactId);
+        this.defaultBranch = defaultBranch;
+    }
+
     public StoreProjectData(String projectId,String groupId,String artifactId)
     {
         super(groupId, artifactId);
         this.projectId = projectId;
     }
 
+    public String getDefaultBranch()
+    {
+        return defaultBranch;
+    }
+
+    public void setDefaultBranch(String defaultBranch)
+    {
+        this.defaultBranch = defaultBranch;
+    }
 
     public String getProjectId()
     {

--- a/legend-depot-model/src/main/java/org/finos/legend/depot/domain/version/VersionValidator.java
+++ b/legend-depot-model/src/main/java/org/finos/legend/depot/domain/version/VersionValidator.java
@@ -19,7 +19,11 @@ import org.finos.legend.sdlc.domain.model.version.VersionId;
 
 public class VersionValidator
 {
-    public static final String MASTER_SNAPSHOT = "master-SNAPSHOT";
+    public static String BRANCH_SNAPSHOT(String branchName)
+    {
+        return branchName + SNAPSHOT;
+    }
+
     private static final String SNAPSHOT = "-SNAPSHOT";
     public static final String VALID_VERSION_ID_TXT = "a valid version string: x.y.z, master-SNAPSHOT or alias: latest = last released version, head = latest unreleased revision";
 

--- a/legend-depot-pure-model-context/src/main/java/org/finos/legend/depot/server/pure/model/context/resources/DeprecatedPureModelContextAPIsResource.java
+++ b/legend-depot-pure-model-context/src/main/java/org/finos/legend/depot/server/pure/model/context/resources/DeprecatedPureModelContextAPIsResource.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
 import org.finos.legend.depot.server.pure.model.context.api.PureModelContextService;
+import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.depot.tracing.resources.BaseResource;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 
@@ -32,7 +33,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 @Path("")
 @Api("Deprecated")
@@ -64,6 +65,6 @@ public class DeprecatedPureModelContextAPIsResource extends BaseResource
                                                         @DefaultValue("true")
                                                         @ApiParam("Whether to return ENTITIES with version in entity path") boolean getDependencies)
     {
-        return handle(GET_REVISION_ENTITIES_AS_PMCD, () -> service.getPureModelContextData(groupId, artifactId,MASTER_SNAPSHOT, clientVersion, versioned, getDependencies));
+        return handle(GET_REVISION_ENTITIES_AS_PMCD, () -> service.getPureModelContextData(groupId, artifactId,BRANCH_SNAPSHOT("master"), clientVersion, versioned, getDependencies));
     }
 }

--- a/legend-depot-pure-model-context/src/test/java/org/finos/legend/depot/server/pure/model/context/TestPureModelContextService.java
+++ b/legend-depot-pure-model-context/src/test/java/org/finos/legend/depot/server/pure/model/context/TestPureModelContextService.java
@@ -24,6 +24,7 @@ import org.finos.legend.depot.services.api.entities.EntitiesService;
 import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.depot.services.entities.EntitiesServiceImpl;
 import org.finos.legend.depot.services.projects.ProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
 import org.finos.legend.depot.store.mongo.TestStoreMongo;
 import org.finos.legend.depot.store.mongo.admin.metrics.QueryMetricsMongo;
@@ -39,7 +40,7 @@ import org.mockito.Mockito;
 import java.net.URL;
 import java.util.List;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.mockito.Mockito.mock;
 
 public class TestPureModelContextService extends TestBaseServices
@@ -54,7 +55,7 @@ public class TestPureModelContextService extends TestBaseServices
     public static final String CLIENT_VERSION = "vX_X_X";
     private final QueryMetricsStore metrics = new QueryMetricsMongo(mongoProvider);
     private final Queue queue = mock(Queue.class);
-    ProjectsService projectsService = new ProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue);
+    ProjectsService projectsService = new ProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue, new ProjectsConfiguration("master"));
     private final PureModelContextService service = new PureModelContextServiceImpl(new EntitiesServiceImpl(entitiesStore, projectsService), projectsService);
 
 
@@ -95,7 +96,7 @@ public class TestPureModelContextService extends TestBaseServices
     @Test
     public void canGetEntitiesAsPureModelContextData()
     {
-        String modelContextDataAsString = service.getPureModelContextDataAsString(TEST_GROUP_ID, "test", MASTER_SNAPSHOT, CLIENT_VERSION, false, false);
+        String modelContextDataAsString = service.getPureModelContextDataAsString(TEST_GROUP_ID, "test", BRANCH_SNAPSHOT("master"), CLIENT_VERSION, false, false);
         Assert.assertNotNull(modelContextDataAsString);
         Assert.assertEquals("{\"_type\":\"data\",\"elements\":[{\"_type\":\"class\",\"constraints\":[],\"name\":\"ClassWithDependency\",\"originalMilestonedProperties\":[],\"package\":\"examples::metadata::test\",\"properties\":[{\"multiplicity\":{\"lowerBound\":1,\"upperBound\":1},\"name\":\"Name\",\"stereotypes\":[],\"taggedValues\":[],\"type\":\"String\"}],\"qualifiedProperties\":[],\"stereotypes\":[],\"superTypes\":[],\"taggedValues\":[]},{\"_type\":\"profile\",\"name\":\"TestProfile\",\"package\":\"examples::metadata::test\",\"stereotypes\":[],\"tags\":[]},{\"_type\":\"class\",\"constraints\":[],\"name\":\"ClientBasic\",\"originalMilestonedProperties\":[],\"package\":\"examples::metadata::test\",\"properties\":[{\"multiplicity\":{\"lowerBound\":1,\"upperBound\":1},\"name\":\"Name\",\"stereotypes\":[],\"taggedValues\":[],\"type\":\"String\"},{\"multiplicity\":{\"lowerBound\":1,\"upperBound\":1},\"name\":\"EntityId\",\"stereotypes\":[],\"taggedValues\":[],\"type\":\"Integer\"},{\"multiplicity\":{\"lowerBound\":1,\"upperBound\":1},\"name\":\"IsActive\",\"stereotypes\":[],\"taggedValues\":[],\"type\":\"Boolean\"},{\"multiplicity\":{\"lowerBound\":1,\"upperBound\":1},\"name\":\"RiskScore\",\"stereotypes\":[],\"taggedValues\":[],\"type\":\"Float\"},{\"multiplicity\":{\"lowerBound\":1,\"upperBound\":1},\"name\":\"IncorporationDate\",\"stereotypes\":[],\"taggedValues\":[],\"type\":\"StrictDate\"},{\"multiplicity\":{\"lowerBound\":0,\"upperBound\":1},\"name\":\"OptionalAlternativeName\",\"stereotypes\":[],\"taggedValues\":[],\"type\":\"String\"},{\"multiplicity\":{\"lowerBound\":0,\"upperBound\":1},\"name\":\"newProperty\",\"stereotypes\":[],\"taggedValues\":[],\"type\":\"String\"}],\"qualifiedProperties\":[],\"stereotypes\":[],\"superTypes\":[],\"taggedValues\":[]},{\"_type\":\"profile\",\"name\":\"TestProfileTwo\",\"package\":\"examples::metadata::test::subpackage\",\"stereotypes\":[],\"tags\":[]}],\"origin\":{\"_type\":\"pointer\",\"sdlcInfo\":{\"_type\":\"alloy\",\"baseVersion\":\"master-SNAPSHOT\",\"packageableElementPointers\":[],\"project\":\"examples.metadata:test\",\"version\":\"none\"},\"serializer\":{\"name\":\"pure\",\"version\":\"vX_X_X\"}},\"serializer\":{\"name\":\"pure\",\"version\":\"vX_X_X\"}}", modelContextDataAsString);
     }
@@ -103,7 +104,7 @@ public class TestPureModelContextService extends TestBaseServices
     @Test(expected = IllegalArgumentException.class)
     public void testNonExistentProject()
     {
-        service.getPureModelContextDataAsString("non.existent.project", "test",MASTER_SNAPSHOT, CLIENT_VERSION, false, false);
+        service.getPureModelContextDataAsString("non.existent.project", "test",BRANCH_SNAPSHOT("master"), CLIENT_VERSION, false, false);
     }
 
     @Test
@@ -112,7 +113,7 @@ public class TestPureModelContextService extends TestBaseServices
 
         EntitiesService mockVersions = Mockito.mock(EntitiesService.class);
         PureModelContextService newService = new PureModelContextServiceImpl(mockVersions, projectsService);
-        Assert.assertThrows("project version not found for test.legend-blank-prod-master-SNAPSHOT", IllegalArgumentException.class, () -> newService.getPureModelContextDataAsString("test.legend", "blank-prod", MASTER_SNAPSHOT, CLIENT_VERSION, false, false));
+        Assert.assertThrows("project version not found for test.legend-blank-prod-master-SNAPSHOT", IllegalArgumentException.class, () -> newService.getPureModelContextDataAsString("test.legend", "blank-prod", BRANCH_SNAPSHOT("master"), CLIENT_VERSION, false, false));
     }
 
     @Test

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/deprecated/DeprecatedDependenciesAPIsResource.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/deprecated/DeprecatedDependenciesAPIsResource.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.depot.domain.entity.ProjectVersionEntities;
 import org.finos.legend.depot.services.api.entities.EntitiesService;
+import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.depot.tracing.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -32,7 +33,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 @Path("")
 @Api("Deprecated")
@@ -64,6 +65,6 @@ public class DeprecatedDependenciesAPIsResource extends BaseResource
                                                                           @QueryParam("includeOrigin") @DefaultValue("false")
                                                                           @ApiParam("Whether to return start of dependency tree") boolean includeOrigin)
     {
-        return handle(GET_REVISION_DEPENDENCY_ENTITIES, () -> this.entitiesService.getDependenciesEntities(groupId, artifactId,MASTER_SNAPSHOT, versioned, transitive, includeOrigin));
+        return handle(GET_REVISION_DEPENDENCY_ENTITIES, () -> this.entitiesService.getDependenciesEntities(groupId, artifactId,BRANCH_SNAPSHOT("master"), versioned, transitive, includeOrigin));
     }
 }

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/deprecated/DeprecatedEntitiesAPIsResource.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/deprecated/DeprecatedEntitiesAPIsResource.java
@@ -19,6 +19,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.depot.services.api.entities.EntitiesService;
+import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.depot.tracing.resources.BaseResource;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 
@@ -34,7 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 @Path("")
 @Api("Deprecated")
@@ -64,7 +65,7 @@ public class DeprecatedEntitiesAPIsResource extends BaseResource
                                           @DefaultValue("false")
                                           @ApiParam("Whether to return ENTITIES with version in entity path") boolean versioned)
     {
-        return handle(GET_REVISION_ENTITIES, () -> this.entitiesService.getEntities(groupId, artifactId, MASTER_SNAPSHOT,versioned));
+        return handle(GET_REVISION_ENTITIES, () -> this.entitiesService.getEntities(groupId, artifactId, BRANCH_SNAPSHOT("master"),versioned));
     }
 
 
@@ -77,7 +78,7 @@ public class DeprecatedEntitiesAPIsResource extends BaseResource
                                            @PathParam("artifactId") String artifactId,
                                            @PathParam("path") String entityPath)
     {
-        return handle(GET_REVISION_ENTITY, GET_REVISION_ENTITY + entityPath, () -> this.entitiesService.getEntity(groupId, artifactId,MASTER_SNAPSHOT, entityPath));
+        return handle(GET_REVISION_ENTITY, GET_REVISION_ENTITY + entityPath, () -> this.entitiesService.getEntity(groupId, artifactId,BRANCH_SNAPSHOT("master"), entityPath));
     }
 
     @GET
@@ -96,6 +97,6 @@ public class DeprecatedEntitiesAPIsResource extends BaseResource
                                           @DefaultValue("true")
                                           @ApiParam("Whether to include ENTITIES from subpackages or only directly in one of the given packages") boolean includeSubPackages)
     {
-        return handle(GET_REVISION_ENTITIES_BY_PACKAGE, GET_REVISION_ENTITIES_BY_PACKAGE + packageName, () -> this.entitiesService.getEntitiesByPackage(groupId, artifactId, MASTER_SNAPSHOT,packageName, versioned, classifierPaths, includeSubPackages));
+        return handle(GET_REVISION_ENTITIES_BY_PACKAGE, GET_REVISION_ENTITIES_BY_PACKAGE + packageName, () -> this.entitiesService.getEntitiesByPackage(groupId, artifactId, BRANCH_SNAPSHOT("master"),packageName, versioned, classifierPaths, includeSubPackages));
     }
 }

--- a/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/deprecated/DeprecatedFileGenerationAPIsResource.java
+++ b/legend-depot-server/src/main/java/org/finos/legend/depot/server/resources/deprecated/DeprecatedFileGenerationAPIsResource.java
@@ -19,6 +19,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.depot.domain.generation.file.FileGeneration;
 import org.finos.legend.depot.services.api.generation.file.FileGenerationsService;
+import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.depot.tracing.resources.BaseResource;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 
@@ -31,7 +32,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Optional;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 @Path("")
 @Api("Deprecated")
@@ -57,7 +58,7 @@ public class DeprecatedFileGenerationAPIsResource extends BaseResource
     public List<Entity> getLatestGenerations(@PathParam("groupId") String groupId,
                                              @PathParam("artifactId") String artifactId)
     {
-        return handle(GET_REVISION_FILE_GENERATION_ENTITIES, () -> this.generationsService.getGenerations(groupId, artifactId, MASTER_SNAPSHOT));
+        return handle(GET_REVISION_FILE_GENERATION_ENTITIES, () -> this.generationsService.getGenerations(groupId, artifactId, BRANCH_SNAPSHOT("master")));
     }
 
 
@@ -69,7 +70,7 @@ public class DeprecatedFileGenerationAPIsResource extends BaseResource
     public List<FileGeneration> getLatestFileGenerations(@PathParam("groupId") String groupId,
                                                           @PathParam("artifactId") String artifactId)
     {
-        return handle(GET_REVISION_FILE_GENERATION, () -> this.generationsService.getFileGenerations(groupId, artifactId,MASTER_SNAPSHOT));
+        return handle(GET_REVISION_FILE_GENERATION, () -> this.generationsService.getFileGenerations(groupId, artifactId,BRANCH_SNAPSHOT("master")));
     }
 
     @GET
@@ -81,7 +82,7 @@ public class DeprecatedFileGenerationAPIsResource extends BaseResource
                                                                @PathParam("artifactId") String artifactId,
                                                                @PathParam("elementPath") String elementPath)
     {
-        return handle(GET_REVISION_FILE_GENERATION_BY_ELEMENT_PATH, () -> this.generationsService.getFileGenerationsByElementPath(groupId, artifactId, MASTER_SNAPSHOT,elementPath));
+        return handle(GET_REVISION_FILE_GENERATION_BY_ELEMENT_PATH, () -> this.generationsService.getFileGenerationsByElementPath(groupId, artifactId, BRANCH_SNAPSHOT("master"),elementPath));
     }
 
     @GET
@@ -93,7 +94,7 @@ public class DeprecatedFileGenerationAPIsResource extends BaseResource
                                                                    @PathParam("artifactId") String artifactId,
                                                                    @PathParam("filePath") String filePath)
     {
-        return handle(GET_REVISION_FILE_GENERATION_BY_FILEPATH, () -> this.generationsService.getFileGenerationsByFilePath(groupId, artifactId, MASTER_SNAPSHOT,filePath));
+        return handle(GET_REVISION_FILE_GENERATION_BY_FILEPATH, () -> this.generationsService.getFileGenerationsByFilePath(groupId, artifactId, BRANCH_SNAPSHOT("master"),filePath));
     }
 
 }

--- a/legend-depot-server/src/test/java/org/finos/legend/depot/server/TestProjectsResource.java
+++ b/legend-depot-server/src/test/java/org/finos/legend/depot/server/TestProjectsResource.java
@@ -18,6 +18,7 @@ package org.finos.legend.depot.server;
 import org.finos.legend.depot.server.resources.ProjectsResource;
 import org.finos.legend.depot.services.TestBaseServices;
 import org.finos.legend.depot.services.projects.ProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
 import org.finos.legend.depot.store.notifications.queue.api.Queue;
 import org.junit.Assert;
@@ -31,7 +32,7 @@ public class TestProjectsResource extends TestBaseServices
 {
     private final QueryMetricsStore metrics = mock(QueryMetricsStore.class);
     private final Queue queue = mock(Queue.class);
-    private ProjectsResource projectsVersionsResource = new ProjectsResource(new ProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue));
+    private ProjectsResource projectsVersionsResource = new ProjectsResource(new ProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue, new ProjectsConfiguration("master")));
 
     @Test
     public void canQueryVersionsForProjectGA()

--- a/legend-depot-server/src/test/java/org/finos/legend/depot/server/TestProjectsVersionsResource.java
+++ b/legend-depot-server/src/test/java/org/finos/legend/depot/server/TestProjectsVersionsResource.java
@@ -19,6 +19,7 @@ import org.finos.legend.depot.domain.project.ProjectVersion;
 import org.finos.legend.depot.server.resources.ProjectsVersionsResource;
 import org.finos.legend.depot.services.TestBaseServices;
 import org.finos.legend.depot.services.projects.ProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
 import org.finos.legend.depot.store.notifications.queue.api.Queue;
 import org.junit.Assert;
@@ -27,14 +28,14 @@ import org.junit.Test;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.mockito.Mockito.mock;
 
 public class TestProjectsVersionsResource extends TestBaseServices
 {
     private final QueryMetricsStore metrics = mock(QueryMetricsStore.class);
     private final Queue queue = mock(Queue.class);
-    private ProjectsVersionsResource projectsVersionsResource = new ProjectsVersionsResource(new ProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue));
+    private ProjectsVersionsResource projectsVersionsResource = new ProjectsVersionsResource(new ProjectsServiceImpl(projectsVersionsStore, projectsStore, metrics, queue, new ProjectsConfiguration("master")));
 
     @Test
     public void canQueryLatestProjectVersionData()
@@ -62,7 +63,7 @@ public class TestProjectsVersionsResource extends TestBaseServices
         Assert.assertTrue(versionData.isPresent());
         Assert.assertEquals(versionData.get().getGroupId(), "examples.metadata");
         Assert.assertEquals(versionData.get().getArtifactId(), "test");
-        Assert.assertEquals(versionData.get().getVersionId(), MASTER_SNAPSHOT);
+        Assert.assertEquals(versionData.get().getVersionId(), BRANCH_SNAPSHOT("master"));
 
         Optional<ProjectsVersionsResource.ProjectVersionDTO> versionData1 = projectsVersionsResource.getProjectVersion("somethig.random", "test","head");
         Assert.assertFalse(versionData1.isPresent());

--- a/legend-depot-server/src/test/java/org/finos/legend/depot/server/TestQueryEntitiesResource.java
+++ b/legend-depot-server/src/test/java/org/finos/legend/depot/server/TestQueryEntitiesResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.depot.services.TestBaseServices;
 import org.finos.legend.depot.services.api.entities.EntitiesService;
 import org.finos.legend.depot.services.entities.EntitiesServiceImpl;
 import org.finos.legend.depot.services.projects.ProjectsServiceImpl;
+import org.finos.legend.depot.services.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.store.admin.api.metrics.QueryMetricsStore;
 import org.finos.legend.depot.store.api.projects.UpdateProjectsVersions;
 import org.finos.legend.depot.store.api.projects.UpdateProjects;
@@ -42,7 +43,7 @@ import java.util.Optional;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -53,7 +54,7 @@ public class TestQueryEntitiesResource extends TestBaseServices
 
     private final QueryMetricsStore metrics = new QueryMetricsMongo(mongoProvider);
     private final Queue queue = mock(Queue.class);
-    private final EntitiesService entitiesService = new EntitiesServiceImpl(entitiesStore,new ProjectsServiceImpl(projectsVersions, projects, metrics, queue));
+    private final EntitiesService entitiesService = new EntitiesServiceImpl(entitiesStore,new ProjectsServiceImpl(projectsVersions, projects, metrics, queue, new ProjectsConfiguration("master")));
     private EntitiesResource entitiesResource = new EntitiesResource(entitiesService);
     private QueryMetricsMongo metricsStore = new QueryMetricsMongo(mongoProvider);
     private QueryMetricsHandler metricsHandler = new QueryMetricsHandler(metricsStore);
@@ -69,7 +70,7 @@ public class TestQueryEntitiesResource extends TestBaseServices
         super.setUpData();
         metricsStore.getCollection().drop();
         loadEntities("PROD-A", "2.3.0");
-        loadEntities("PROD-A", MASTER_SNAPSHOT);
+        loadEntities("PROD-A", BRANCH_SNAPSHOT("master"));
         when(projects.find("examples.metadata","test")).thenReturn(Optional.of(new StoreProjectData("mock","examples.metadata","test")));
         when(projects.find("example.services.test", "test")).thenReturn(Optional.of(new StoreProjectData("mock","example.services.test", "test")));
         when(projectsVersions.find("examples.metadata","test", "2.3.0")).thenReturn(Optional.of(new StoreProjectVersionData("examples.metadata","test", "2.3.0")));

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/admin/migrations/ProjectToProjectVersionMigration.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/admin/migrations/ProjectToProjectVersionMigration.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.finos.legend.depot.store.mongo.core.BaseMongo.ARTIFACT_ID;
 import static org.finos.legend.depot.store.mongo.core.BaseMongo.GROUP_ID;
 import static org.finos.legend.depot.store.mongo.core.BaseMongo.VERSION_ID;
@@ -85,8 +85,8 @@ public final class ProjectToProjectVersionMigration
                 List<String> versions = document.getList("versions",String.class);
 
                 LOGGER.info(String.format("versions that should be inserted [%s]",versions.size()));
-                versionCollection.insertOne(buildDocument(createStoreProjectData(document, MASTER_SNAPSHOT)));
-                LOGGER.info(String.format("%s-%s-%s insertion completed",groupId,artifactId, MASTER_SNAPSHOT));
+                versionCollection.insertOne(buildDocument(createStoreProjectData(document, BRANCH_SNAPSHOT("master"))));
+                LOGGER.info(String.format("%s-%s-%s insertion completed",groupId,artifactId, BRANCH_SNAPSHOT("master")));
 
                 versions.forEach(version ->
                 {

--- a/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/entities/EntitiesMongo.java
+++ b/legend-depot-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/entities/EntitiesMongo.java
@@ -59,13 +59,13 @@ import java.util.stream.Stream;
 import static com.mongodb.client.model.Aggregates.group;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
-import static com.mongodb.client.model.Filters.ne;
+import static com.mongodb.client.model.Filters.not;
 import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.currentDate;
 import static com.mongodb.client.model.Updates.set;
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, UpdateEntities
 {
@@ -267,7 +267,7 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
         List<Bson> filters = new ArrayList<>();
         filters.add(eq(ENTITY_CLASSIFIER_PATH, classifier));
         filters.add(eq(VERSIONED_ENTITY, versioned));
-        filters.add(eq(VERSION_ID, MASTER_SNAPSHOT));
+        filters.add(regex(VERSION_ID, BRANCH_SNAPSHOT("")));
         if (search != null)
         {
             filters.add(Filters.regex(ENTITY_PATH, Pattern.quote(search), "i"));
@@ -282,13 +282,13 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
     @Override
     public List<StoredEntity> findReleasedEntitiesByClassifier(String classifier, boolean summary, boolean versionedEntities)
     {
-        return transform(summary, executeFind(and(and(eq(ENTITY_CLASSIFIER_PATH, classifier), eq(VERSIONED_ENTITY, versionedEntities)), ne(VERSION_ID, MASTER_SNAPSHOT))));
+        return transform(summary, executeFind(and(and(eq(ENTITY_CLASSIFIER_PATH, classifier), eq(VERSIONED_ENTITY, versionedEntities)), not(regex(VERSION_ID, BRANCH_SNAPSHOT(""))))));
     }
 
     @Override
     public List<StoredEntity> findLatestEntitiesByClassifier(String classifier, boolean summary, boolean versioned)
     {
-        return transform(summary, executeFind(and(and(eq(ENTITY_CLASSIFIER_PATH, classifier), eq(VERSION_ID, MASTER_SNAPSHOT)), eq(VERSIONED_ENTITY, versioned))));
+        return transform(summary, executeFind(and(and(eq(ENTITY_CLASSIFIER_PATH, classifier), regex(VERSION_ID, BRANCH_SNAPSHOT(""))), eq(VERSIONED_ENTITY, versioned))));
     }
 
     public List<StoredEntity> findEntitiesByClassifier(String classifier, boolean summary, boolean versioned)
@@ -335,7 +335,7 @@ public class EntitiesMongo extends BaseMongo<StoredEntity> implements Entities, 
 
     public long getVersionEntityCount()
     {
-        return getCollection().countDocuments(ne(VERSION_ID, MASTER_SNAPSHOT));
+        return getCollection().countDocuments(not(regex(VERSION_ID, BRANCH_SNAPSHOT(""))));
     }
 
 

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/admin/migrations/TestProjectVersionMigrations.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/admin/migrations/TestProjectVersionMigrations.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.finos.legend.depot.store.mongo.core.BaseMongo.convert;
 
 public class TestProjectVersionMigrations extends TestStoreMongo
@@ -95,7 +95,7 @@ public class TestProjectVersionMigrations extends TestStoreMongo
         StoreProjectVersionData result = convert(new ObjectMapper(),mongoProvider.getCollection("versions").find().first(), StoreProjectVersionData.class);
         Assert.assertEquals(result.getGroupId(), "examples.metadata");
         Assert.assertEquals(result.getArtifactId(), "test");
-        Assert.assertEquals(result.getVersionId(), MASTER_SNAPSHOT);
+        Assert.assertEquals(result.getVersionId(), BRANCH_SNAPSHOT("master"));
     }
 
     @Test

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryClassifierPath.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryClassifierPath.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import java.net.URL;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 public class TestQueryClassifierPath extends TestStoreMongo
 {
@@ -36,8 +36,8 @@ public class TestQueryClassifierPath extends TestStoreMongo
     {
         String CPATH = "meta::pure::metamodel::extension::Profile";
         setUpEntitiesDataFromFile(ENTITIES_FILE);
-        Assert.assertEquals(2, mongo.getVersionEntityCount("examples.metadata", "test",MASTER_SNAPSHOT));
-        Assert.assertEquals(1, mongo.getVersionEntityCount("examples.metadata", "test2",MASTER_SNAPSHOT));
+        Assert.assertEquals(2, mongo.getVersionEntityCount("examples.metadata", "test",BRANCH_SNAPSHOT("master")));
+        Assert.assertEquals(1, mongo.getVersionEntityCount("examples.metadata", "test2",BRANCH_SNAPSHOT("master")));
         Assert.assertEquals(3, mongo.findLatestEntitiesByClassifier(CPATH, null, null, false, false).size());
         Assert.assertEquals(2, mongo.findLatestEntitiesByClassifier(CPATH, null, 2, false, false).size());
         Assert.assertEquals(1, mongo.findLatestEntitiesByClassifier(CPATH, "TestProfileTwo", 2, false, false).size());
@@ -48,8 +48,8 @@ public class TestQueryClassifierPath extends TestStoreMongo
     {
         String CPATH = "meta::pure::metamodel::extension::Profile";
         setUpEntitiesDataFromFile(ENTITIES_FILE);
-        Assert.assertEquals(2, mongo.getVersionEntityCount("examples.metadata", "test",MASTER_SNAPSHOT));
-        Assert.assertEquals(1, mongo.getVersionEntityCount("examples.metadata", "test2",MASTER_SNAPSHOT));
+        Assert.assertEquals(2, mongo.getVersionEntityCount("examples.metadata", "test",BRANCH_SNAPSHOT("master")));
+        Assert.assertEquals(1, mongo.getVersionEntityCount("examples.metadata", "test2",BRANCH_SNAPSHOT("master")));
         Assert.assertEquals(8, mongo.findReleasedEntitiesByClassifier(CPATH, null, null, null, false, false).size());
         Assert.assertEquals(2, mongo.findReleasedEntitiesByClassifier(CPATH, null, null, 2, false, false).size());
         Assert.assertEquals(4, mongo.findReleasedEntitiesByClassifier(CPATH, "TestProfileTwo", null, null, false, false).size());

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryRevisions.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryRevisions.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 public class TestQueryRevisions extends TestStoreMongo
 {
@@ -42,7 +42,7 @@ public class TestQueryRevisions extends TestStoreMongo
     @Test
     public void canQueryAllEntityMetadataByProjectVersion()
     {
-        List<Entity> entityList = revisionsMongo.getAllEntities("examples.metadata", "test",MASTER_SNAPSHOT);
+        List<Entity> entityList = revisionsMongo.getAllEntities("examples.metadata", "test",BRANCH_SNAPSHOT("master"));
         Assert.assertNotNull(entityList);
         Assert.assertEquals(8, entityList.size());
         List<String> paths = new ArrayList<>();
@@ -55,7 +55,7 @@ public class TestQueryRevisions extends TestStoreMongo
     @Test
     public void canQueryEntityMetadataByProjectVersion()
     {
-        List<Entity> entityList = revisionsMongo.getAllEntities("examples.metadata", "test", MASTER_SNAPSHOT);
+        List<Entity> entityList = revisionsMongo.getAllEntities("examples.metadata", "test", BRANCH_SNAPSHOT("master"));
         Assert.assertNotNull(entityList);
         Assert.assertEquals(8, entityList.size());
     }
@@ -63,7 +63,7 @@ public class TestQueryRevisions extends TestStoreMongo
     @Test
     public void canQueryEntityMetadataByProjectVersionVersionInPath()
     {
-        List<Entity> entityList = revisionsMongo.getEntities("examples.metadata", "test", MASTER_SNAPSHOT,true);
+        List<Entity> entityList = revisionsMongo.getEntities("examples.metadata", "test", BRANCH_SNAPSHOT("master"),true);
         Assert.assertNotNull(entityList);
         Assert.assertEquals(4, entityList.size());
     }
@@ -71,7 +71,7 @@ public class TestQueryRevisions extends TestStoreMongo
     @Test
     public void canQueryEntityMetadataByProjectVersionPath()
     {
-        Entity entity = revisionsMongo.getEntity("examples.metadata", "test", MASTER_SNAPSHOT,"examples::metadata::test::TestProfile").get();
+        Entity entity = revisionsMongo.getEntity("examples.metadata", "test", BRANCH_SNAPSHOT("master"),"examples::metadata::test::TestProfile").get();
         Assert.assertNotNull(entity);
         Assert.assertEquals("examples::metadata::test::TestProfile", entity.getPath());
         Assert.assertEquals("meta::pure::metamodel::extension::Profile", entity.getClassifierPath());
@@ -82,7 +82,7 @@ public class TestQueryRevisions extends TestStoreMongo
     @Test
     public void canQueryEntityMetadataByProjectVersionPackage()
     {
-        List<Entity> entities = revisionsMongo.getEntitiesByPackage("examples.metadata", "test", MASTER_SNAPSHOT,"examples::metadata::test", false, null, false);
+        List<Entity> entities = revisionsMongo.getEntitiesByPackage("examples.metadata", "test", BRANCH_SNAPSHOT("master"),"examples::metadata::test", false, null, false);
         Assert.assertNotNull(entities);
         Assert.assertEquals(3, entities.size());
         for (Entity entity : entities)
@@ -95,7 +95,7 @@ public class TestQueryRevisions extends TestStoreMongo
     @Test
     public void canQueryEntityMetadataByProjectSubPackage()
     {
-        List<Entity> entities = revisionsMongo.getEntitiesByPackage("examples.metadata", "test", MASTER_SNAPSHOT,"examples::metadata::test", false, null, true);
+        List<Entity> entities = revisionsMongo.getEntitiesByPackage("examples.metadata", "test", BRANCH_SNAPSHOT("master"),"examples::metadata::test", false, null, true);
         Assert.assertNotNull(entities);
         Assert.assertEquals(4, entities.size());
         for (Entity entity : entities)
@@ -107,7 +107,7 @@ public class TestQueryRevisions extends TestStoreMongo
     @Test
     public void canQueryEntityMetadataByProjectVersionPackages()
     {
-        List<Entity> entities = revisionsMongo.getEntitiesByPackage("examples.metadata", "test", MASTER_SNAPSHOT,"examples::metadata::test::vX_X_X::examples::metadata::test", true, null, false);
+        List<Entity> entities = revisionsMongo.getEntitiesByPackage("examples.metadata", "test", BRANCH_SNAPSHOT("master"),"examples::metadata::test::vX_X_X::examples::metadata::test", true, null, false);
         Assert.assertNotNull(entities);
         Assert.assertEquals(3, entities.size());
         for (Entity entity : entities)
@@ -120,7 +120,7 @@ public class TestQueryRevisions extends TestStoreMongo
     @Test
     public void canQueryEntityMetadataByProjectVersionPackageVersionedSubpackages()
     {
-        List<Entity> entities = revisionsMongo.getEntitiesByPackage("examples.metadata", "test", MASTER_SNAPSHOT,"examples::metadata::test::vX_X_X::examples::metadata::test", true, null, true);
+        List<Entity> entities = revisionsMongo.getEntitiesByPackage("examples.metadata", "test", BRANCH_SNAPSHOT("master"),"examples::metadata::test::vX_X_X::examples::metadata::test", true, null, true);
         Assert.assertNotNull(entities);
         Assert.assertEquals(4, entities.size());
         for (Entity entity : entities)

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryVersions.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryVersions.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 
 public class TestQueryVersions extends TestStoreMongo
@@ -120,7 +120,7 @@ public class TestQueryVersions extends TestStoreMongo
 
         Set<String> paths = entities.stream().map(en -> en.getEntity().getPath()).collect(Collectors.toSet());
 
-        List<Entity> withoutVersions = versionsMongo.getEntities("examples.metadata", "test", MASTER_SNAPSHOT, true);
+        List<Entity> withoutVersions = versionsMongo.getEntities("examples.metadata", "test", BRANCH_SNAPSHOT("master"), true);
         Assert.assertNotNull(withoutVersions);
         Set<String> allPaths = withoutVersions.stream().map(Entity::getPath).collect(Collectors.toSet());
 

--- a/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/generation/file/TestFileGenerationsStore.java
+++ b/legend-depot-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/generation/file/TestFileGenerationsStore.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 public class TestFileGenerationsStore extends TestStoreMongo
 {
@@ -59,7 +59,7 @@ public class TestFileGenerationsStore extends TestStoreMongo
         Assert.assertEquals(3, result.size());
 
         Assert.assertEquals(0, generations.findByElementPath(TEST_GROUP_ID, TEST_ARTIFACT_ID, "12.3.2", "com::avrogen").size());
-        Assert.assertEquals(0, generations.findByElementPath(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT, "com::jsonGen").size());
+        Assert.assertEquals(0, generations.findByElementPath(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master"), "com::jsonGen").size());
 
         List<StoredFileGeneration> result2 = generations.findByElementPath(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.3.3", "com::avrogen");
         Assert.assertEquals(3, result2.size());
@@ -75,7 +75,7 @@ public class TestFileGenerationsStore extends TestStoreMongo
         Assert.assertEquals(3, result.size());
 
         Assert.assertEquals(0, generations.findByType(TEST_GROUP_ID, TEST_ARTIFACT_ID, "12.3.2", "java").size());
-        Assert.assertEquals(0, generations.findByType(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT, "java").size());
+        Assert.assertEquals(0, generations.findByType(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master"), "java").size());
 
     }
 
@@ -85,7 +85,7 @@ public class TestFileGenerationsStore extends TestStoreMongo
         Assert.assertTrue(generations.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.3.3", "/examples/metadata/test/ClientBasic.avro").isPresent());
         Assert.assertTrue(generations.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "2.3.3", "/examples/generated/test/other/MyOutput.json").isPresent());
         Assert.assertFalse(generations.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, "0.01.1", "/examples/metadata/test/ClientBasic.avro").isPresent());
-        Assert.assertFalse(generations.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, MASTER_SNAPSHOT, "com/finos/sdgashdf").isPresent());
+        Assert.assertFalse(generations.get(TEST_GROUP_ID, TEST_ARTIFACT_ID, BRANCH_SNAPSHOT("master"), "com/finos/sdgashdf").isPresent());
     }
 
 }

--- a/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/resources/projects/ManageProjectsResource.java
+++ b/legend-depot-store-server/src/main/java/org/finos/legend/depot/store/resources/projects/ManageProjectsResource.java
@@ -17,6 +17,7 @@ package org.finos.legend.depot.store.resources.projects;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.finos.legend.depot.core.authorisation.api.AuthorisationProvider;
 import org.finos.legend.depot.core.authorisation.resources.BaseAuthorisedResource;
 import org.finos.legend.depot.domain.api.MetadataEventResponse;
@@ -32,8 +33,10 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.security.Principal;
+import java.util.Optional;
 
 @Path("")
 @Api("Projects")
@@ -61,7 +64,7 @@ public class ManageProjectsResource extends BaseAuthorisedResource
     @Path("/projects/{projectId}/{groupId}/{artifactId}")
     @ApiOperation(ResourceLoggingAndTracing.CREATE_EMPTY_PROJECT)
     @Produces(MediaType.APPLICATION_JSON)
-    public StoreProjectData updateProject(@PathParam("projectId") String projectId, @PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId)
+    public StoreProjectData updateProject(@PathParam("projectId") String projectId, @PathParam("groupId") String groupId, @PathParam("artifactId") String artifactId, @QueryParam("defaultBranch") @ApiParam String defaultBranch)
     {
         return handle(
                 ResourceLoggingAndTracing.CREATE_EMPTY_PROJECT,
@@ -69,7 +72,7 @@ public class ManageProjectsResource extends BaseAuthorisedResource
                 () ->
                 {
                     validateUser();
-                    return projectApi.createOrUpdate(new StoreProjectData(projectId, groupId, artifactId));
+                    return projectApi.createOrUpdate(new StoreProjectData(projectId, groupId, artifactId, defaultBranch));
                 });
     }
 

--- a/legend-depot-store-status/src/test/java/org/finos/legend/depot/store/status/TestStatusServices.java
+++ b/legend-depot-store-status/src/test/java/org/finos/legend/depot/store/status/TestStatusServices.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.finos.legend.depot.domain.version.VersionValidator.MASTER_SNAPSHOT;
+import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 
 public class TestStatusServices extends TestStoreMongo
 {
@@ -90,7 +90,7 @@ public class TestStatusServices extends TestStoreMongo
     @Test
     public void getRevisionsCount()
     {
-        StoreStatus.DocumentCounts counts = statusService.getDocumentCounts("examples.metadata", "test",MASTER_SNAPSHOT);
+        StoreStatus.DocumentCounts counts = statusService.getDocumentCounts("examples.metadata", "test",BRANCH_SNAPSHOT("master"));
         Assert.assertNotNull(counts);
         Assert.assertEquals(8, counts.totalVersionEntities);
     }


### PR DESCRIPTION
Recognize the default branch for the project being it ‘main’, ‘master’, or something else.

## Implementation Details
# Metadata Server:
When head is used as versionId getting expected results for following apis:
/generations/{groupId}/{artifactId}/versions/{versionId}
/projects/{groupId}/{artifactId}/{versionId}/generations
/projects/{groupId}/{artifactId}/versions/{versionId}
/projects/{groupId}/{artifactId}/versions/{versionId}/dependantProjects
/projects/{groupId}/{artifactId}/versions/{versionId}/dependencies
/projects/{groupId}/{artifactId}/versions/{versionId}/entities
/projects/{groupId}/{artifactId}/versions/{versionId}/projectDependencies
/projects/{groupId}/{artifactId}/versions/{versionId}/pureModelContextData
/versions/{groupId}/{artifactId}/{versionId}

Additionally payload of following API is changed:
/project-configurations

# Metadata Store Manager:
Optional API call:
/projects/{projectId}/{groupId}/{artifactId}?defaultBranch={defaultBranch} - to set branch for snapshots
Existing API:
/projects/{projectId}/{groupId}/{artifactId} - as defaultBranch is not provided config default will be used for resolving (entry will have null value in database)

Both servers additional configuration entry:
"projects": {"defaultBranch": "master"},