### PR TITLE
Optimize entity retrieval with classifier filters

### DIFF
--- a/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/tracing/resources/ResourceLoggingAndTracing.java
+++ b/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/tracing/resources/ResourceLoggingAndTracing.java
@@ -33,7 +33,7 @@ public class ResourceLoggingAndTracing
     public static final String GET_VERSIONS_DEPENDENCY_ENTITIES = "get versions dependencies entities";
     public static final String GET_VERSION_ENTITIES_AS_PMCD = "get version entities as PMCD";
     public static final String GET_VERSION_ENTITY = "get version entity";
-    public static final String GET_VERSION_ENTITIES_BY_PACKAGE = "get version entities by package";
+    public static final String GET_VERSION_ENTITIES_BY_FILTER = "get version entities by filter";
     public static final String GET_VERSIONS = "get versions";
     public static final String UPDATE_ALL_VERSIONS = "refresh all versions";
     public static final String UPDATE_VERSION = "refresh version";

--- a/legend-depot-entities-services/src/main/java/org/finos/legend/depot/server/resources/entities/EntitiesResource.java
+++ b/legend-depot-entities-services/src/main/java/org/finos/legend/depot/server/resources/entities/EntitiesResource.java
@@ -37,7 +37,7 @@ import javax.ws.rs.core.Response;
 import java.util.Set;
 
 import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_ENTITIES;
-import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_ENTITIES_BY_PACKAGE;
+import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_ENTITIES_BY_FILTER;
 import static org.finos.legend.depot.tracing.resources.ResourceLoggingAndTracing.GET_VERSION_ENTITY;
 
 @Path("")
@@ -80,19 +80,20 @@ public class EntitiesResource extends BaseResource
 
     @GET
     @Path("/projects/{groupId}/{artifactId}/versions/{versionId}/entities")
-    @ApiOperation(GET_VERSION_ENTITIES_BY_PACKAGE)
+    @ApiOperation(GET_VERSION_ENTITIES_BY_FILTER)
     @Produces(MediaType.APPLICATION_JSON)
     public Response getEntities(@PathParam("groupId") String groupId,
                                     @PathParam("artifactId") String artifactId,
                                     @PathParam("versionId") @ApiParam(value = VersionValidator.VALID_VERSION_ID_TXT) String versionId,
-                                    @QueryParam("package") String packageName,
+                                    @QueryParam("package")
+                                    @ApiParam("Restrict ENTITIES to only this package if provided") String packageName,
                                     @QueryParam("classifierPath") @ApiParam("Only include ENTITIES with one of these classifier paths.") Set<String> classifierPaths,
                                     @QueryParam("includeSubPackages")
                                     @DefaultValue("true")
-                                    @ApiParam("Whether to include ENTITIES from subpackages or only directly in one of the given packages") boolean includeSubPackages,
+                                    @ApiParam("Whether to include ENTITIES from subpackages or only directly in one of the given packages. Only used if packageName is provided") boolean includeSubPackages,
                                     @Context Request request
     )
     {
-        return handle(GET_VERSION_ENTITIES_BY_PACKAGE, GET_VERSION_ENTITIES_BY_PACKAGE + packageName, () -> entitiesService.getEntitiesByPackage(groupId, artifactId, versionId, packageName, classifierPaths, includeSubPackages), request, () -> EtagBuilder.create().withGAV(groupId, artifactId, versionId).build());
+        return handle(GET_VERSION_ENTITIES_BY_FILTER, GET_VERSION_ENTITIES_BY_FILTER + packageName, () -> entitiesService.getEntitiesByPackage(groupId, artifactId, versionId, packageName, classifierPaths, includeSubPackages), request, () -> EtagBuilder.create().withGAV(groupId, artifactId, versionId).build());
     }
 }

--- a/legend-depot-entities-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryVersions.java
+++ b/legend-depot-entities-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/entities/TestQueryVersions.java
@@ -70,6 +70,18 @@ public class TestQueryVersions extends TestStoreMongo
     }
 
     @Test
+    public void canQueryEntityMetadataByProjectVersionPackageAll()
+    {
+        List<Entity> entities = versionsMongo.getEntitiesByPackage("examples.metadata", "test", "2.2.0", null,  null, false);
+        Assert.assertNotNull(entities);
+        Assert.assertEquals(3, entities.size());
+        for (Entity entity : entities)
+        {
+            Assert.assertTrue(entity.getContent().get("package").toString().startsWith("examples::metadata::test"));
+        }
+    }
+
+    @Test
     public void canQueryEntityMetadataByProjectVersionPackage()
     {
         List<Entity> entities = versionsMongo.getEntitiesByPackage("examples.metadata", "test", "2.2.0", "examples::metadata::test",  null, false);


### PR DESCRIPTION
Skips package filter when package not defined to save on possibly expensive regex matching. This changes behaviour in that if a package is not defined, we will retrieve all entities as opposed to no entities.

Improve efficiency of classifier filtering by executing filter on db index instead of in memory filter.

Clarify entities by package api description.

Optimizes imports.