### PR TITLE
New Endpoint - Querying project versions by creation date

### DIFF
--- a/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
+++ b/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
@@ -31,6 +31,8 @@ public interface ProjectsService
 {
     List<StoreProjectData> getAllProjectCoordinates();
 
+    List<StoreProjectVersionData> findByCreationDate(long createdFrom, long createdTo);
+
     /**
      * NOTE: page starting from 1
      */

--- a/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
+++ b/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
@@ -31,7 +31,7 @@ public interface ProjectsService
 {
     List<StoreProjectData> getAllProjectCoordinates();
 
-    List<StoreProjectVersionData> findByCreationDate(long createdFrom, long createdTo);
+    List<StoreProjectVersionData> findByUpdatedDate(long updatedFrom, long updatedTo);
 
     /**
      * NOTE: page starting from 1

--- a/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/store/api/projects/ProjectsVersions.java
+++ b/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/store/api/projects/ProjectsVersions.java
@@ -24,7 +24,7 @@ public interface ProjectsVersions
 {
     List<StoreProjectVersionData> getAll();
 
-    List<StoreProjectVersionData> findByCreationDate(long createdFrom, long createdTo);
+    List<StoreProjectVersionData> findByUpdatedDate(long updatedFrom, long updatedTo);
 
     List<StoreProjectVersionData> find(String groupId, String artifactId);
 

--- a/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/store/api/projects/ProjectsVersions.java
+++ b/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/store/api/projects/ProjectsVersions.java
@@ -24,6 +24,8 @@ public interface ProjectsVersions
 {
     List<StoreProjectVersionData> getAll();
 
+    List<StoreProjectVersionData> findByCreationDate(long createdFrom, long createdTo);
+
     List<StoreProjectVersionData> find(String groupId, String artifactId);
 
     Optional<StoreProjectVersionData> find(String groupId, String artifactId, String versionId);

--- a/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/store/model/projects/StoreProjectVersionData.java
+++ b/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/store/model/projects/StoreProjectVersionData.java
@@ -34,9 +34,8 @@ public class StoreProjectVersionData extends VersionedData implements HasIdentif
     private boolean evicted = false;
     @JsonProperty
     private Date creationDate;
-    //TODO: understand how to populate last updated
     @JsonProperty
-    private Date lastUpdated;
+    private Date updated;
     @JsonProperty
     private ProjectVersionData versionData = new ProjectVersionData();
     @JsonProperty
@@ -71,16 +70,6 @@ public class StoreProjectVersionData extends VersionedData implements HasIdentif
         this.creationDate = creationDate;
     }
 
-    public Date getLastUpdated()
-    {
-        return lastUpdated;
-    }
-
-    public void setLastUpdated(Date lastUpdated)
-    {
-        this.lastUpdated = lastUpdated;
-    }
-
     public boolean isEvicted()
     {
         return evicted;
@@ -109,6 +98,11 @@ public class StoreProjectVersionData extends VersionedData implements HasIdentif
     public void setTransitiveDependenciesReport(VersionDependencyReport transitiveDependenciesReport)
     {
         this.transitiveDependenciesReport = transitiveDependenciesReport;
+    }
+
+    public Date getUpdated()
+    {
+        return updated;
     }
 
     @Override

--- a/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/server/resources/versions/ProjectsVersionsResource.java
+++ b/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/server/resources/versions/ProjectsVersionsResource.java
@@ -35,11 +35,16 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+
+import static org.finos.legend.depot.domain.DatesHandler.toTime;
 
 @Path("")
 @Api("Versions")
@@ -52,6 +57,18 @@ public class ProjectsVersionsResource extends TracingResource
     public ProjectsVersionsResource(ProjectsService projectVersionApi)
     {
         this.projectVersionApi = projectVersionApi;
+    }
+
+
+    @GET
+    @Path("/projects/versions/{createdFrom}")
+    @ApiOperation(ResourceLoggingAndTracing.GET_VERSIONS_BY_CREATION_DATE)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<StoreProjectVersionData> findByCreationDate(@PathParam("createdFrom") @ApiParam(value = "Created From Date value in milliseconds (UTC) ") long createdFrom,
+                                                            @QueryParam("createdTo") @ApiParam(value = "Created To Date value in milliseconds (UTC) ")  Long createdTo)
+    {
+        return handle(ResourceLoggingAndTracing.GET_VERSIONS_BY_CREATION_DATE,
+                () -> projectVersionApi.findByCreationDate(createdFrom, createdTo == null ? toTime(LocalDateTime.now()) : createdTo));
     }
 
     @GET

--- a/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/server/resources/versions/ProjectsVersionsResource.java
+++ b/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/server/resources/versions/ProjectsVersionsResource.java
@@ -61,14 +61,14 @@ public class ProjectsVersionsResource extends TracingResource
 
 
     @GET
-    @Path("/projects/versions/{createdFrom}")
-    @ApiOperation(ResourceLoggingAndTracing.GET_VERSIONS_BY_CREATION_DATE)
+    @Path("/projects/versions/{updatedFrom}")
+    @ApiOperation(ResourceLoggingAndTracing.GET_VERSIONS_BY_LASTUPDATE_DATE)
     @Produces(MediaType.APPLICATION_JSON)
-    public List<StoreProjectVersionData> findByCreationDate(@PathParam("createdFrom") @ApiParam(value = "Created From Date value in milliseconds (UTC) ") long createdFrom,
-                                                            @QueryParam("createdTo") @ApiParam(value = "Created To Date value in milliseconds (UTC) ")  Long createdTo)
+    public List<StoreProjectVersionData> findByUpdatedDate(@PathParam("updatedFrom") @ApiParam(value = "Updated From Date value in milliseconds (UTC) ") long updatedFrom,
+                                                            @QueryParam("updatedTo") @ApiParam(value = "Updated To Date value in milliseconds (UTC) ")  Long updatedTo)
     {
-        return handle(ResourceLoggingAndTracing.GET_VERSIONS_BY_CREATION_DATE,
-                () -> projectVersionApi.findByCreationDate(createdFrom, createdTo == null ? toTime(LocalDateTime.now()) : createdTo));
+        return handle(ResourceLoggingAndTracing.GET_VERSIONS_BY_LASTUPDATE_DATE,
+                () -> projectVersionApi.findByUpdatedDate(updatedFrom, updatedTo == null ? toTime(LocalDateTime.now()) : updatedTo));
     }
 
     @GET

--- a/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
+++ b/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
@@ -120,9 +120,9 @@ public class ProjectsServiceImpl implements ProjectsService
     }
 
     @Override
-    public List<StoreProjectVersionData> findByCreationDate(long createdFrom, long createdTo)
+    public List<StoreProjectVersionData> findByUpdatedDate(long updatedFrom, long updatedTo)
     {
-        return projectsVersions.findByCreationDate(createdFrom, createdTo);
+        return projectsVersions.findByUpdatedDate(updatedFrom, updatedTo);
     }
 
     @Override

--- a/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
+++ b/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
@@ -120,6 +120,12 @@ public class ProjectsServiceImpl implements ProjectsService
     }
 
     @Override
+    public List<StoreProjectVersionData> findByCreationDate(long createdFrom, long createdTo)
+    {
+        return projectsVersions.findByCreationDate(createdFrom, createdTo);
+    }
+
+    @Override
     public List<StoreProjectVersionData> find(String groupId, String artifactId)
     {
         return projectsVersions.find(groupId, artifactId);

--- a/legend-depot-core-data-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/projects/ProjectsVersionsMongo.java
+++ b/legend-depot-core-data-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/projects/ProjectsVersionsMongo.java
@@ -37,11 +37,15 @@ import java.util.Optional;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.gte;
+import static com.mongodb.client.model.Filters.lt;
 
 public class ProjectsVersionsMongo extends BaseMongo<StoreProjectVersionData> implements ProjectsVersions, UpdateProjectsVersions
 {
     public static final String COLLECTION = "versions";
     private static final String VERSION_DATA_EXCLUDED = "versionData.excluded";
+    // Creation date field on store project versions used for time base querying
+    private static final String CREATION_DATE = "creationDate";
 
     @Inject
     public ProjectsVersionsMongo(@Named("mongoDatabase") MongoDatabase databaseProvider)
@@ -58,6 +62,21 @@ public class ProjectsVersionsMongo extends BaseMongo<StoreProjectVersionData> im
     public List<StoreProjectVersionData> getAll()
     {
         return getAllStoredEntities();
+    }
+
+    /** Return the list of all stored entities which have been created from the given
+     *  timestamp or beyond.
+     *  Records with Created time matching the given input will also be returned.
+     *
+     * @param createdFrom - the created from timestamp in milliseconds (UTC) (inclusive)
+     * @param createdTo - the created to timestamp in milliseconds (UTC) (exclusive)
+     * @return - list of all stored entities which have been created from and beyond the given created from time till
+     *  the given created to time
+     */
+    @Override
+    public List<StoreProjectVersionData> findByCreationDate(long createdFrom, long createdTo)
+    {
+        return find(and(gte(CREATION_DATE, createdFrom),(lt(CREATION_DATE, createdTo))));
     }
 
     @Override

--- a/legend-depot-core-data-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/projects/ProjectsVersionsMongo.java
+++ b/legend-depot-core-data-store-mongo/src/main/java/org/finos/legend/depot/store/mongo/projects/ProjectsVersionsMongo.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.mongodb.client.model.Filters.and;
-import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.gte;
 import static com.mongodb.client.model.Filters.lt;
 
@@ -44,8 +43,6 @@ public class ProjectsVersionsMongo extends BaseMongo<StoreProjectVersionData> im
 {
     public static final String COLLECTION = "versions";
     private static final String VERSION_DATA_EXCLUDED = "versionData.excluded";
-    // Creation date field on store project versions used for time base querying
-    private static final String CREATION_DATE = "creationDate";
 
     @Inject
     public ProjectsVersionsMongo(@Named("mongoDatabase") MongoDatabase databaseProvider)
@@ -64,19 +61,19 @@ public class ProjectsVersionsMongo extends BaseMongo<StoreProjectVersionData> im
         return getAllStoredEntities();
     }
 
-    /** Return the list of all stored entities which have been created from the given
+    /** Return the list of all stored entities which have been updated from the given
      *  timestamp or beyond.
-     *  Records with Created time matching the given input will also be returned.
+     *  Records with updated time matching the given input will also be returned.
      *
-     * @param createdFrom - the created from timestamp in milliseconds (UTC) (inclusive)
-     * @param createdTo - the created to timestamp in milliseconds (UTC) (exclusive)
-     * @return - list of all stored entities which have been created from and beyond the given created from time till
-     *  the given created to time
+     * @param updatedFrom - the updated from timestamp in milliseconds (UTC) (inclusive)
+     * @param updatedTo - the updated to timestamp in milliseconds (UTC) (exclusive)
+     * @return - list of all stored entities which have been updated from and beyond the given updated from time till
+     *  the given updated to time
      */
     @Override
-    public List<StoreProjectVersionData> findByCreationDate(long createdFrom, long createdTo)
+    public List<StoreProjectVersionData> findByUpdatedDate(long updatedFrom, long updatedTo)
     {
-        return find(and(gte(CREATION_DATE, createdFrom),(lt(CREATION_DATE, createdTo))));
+        return find(and(gte(UPDATED, updatedFrom),(lt(UPDATED, updatedTo))));
     }
 
     @Override

--- a/legend-depot-core-data-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/projects/TestQueryProjectVersionApi.java
+++ b/legend-depot-core-data-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/projects/TestQueryProjectVersionApi.java
@@ -22,8 +22,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import static org.finos.legend.depot.domain.DatesHandler.toTime;
 
 
 public class TestQueryProjectVersionApi extends CoreDataMongoStoreTests
@@ -42,6 +45,23 @@ public class TestQueryProjectVersionApi extends CoreDataMongoStoreTests
         List<StoreProjectVersionData> allConfigs = projectsVersionsAPI.getAll();
         Assert.assertNotNull(allConfigs);
         Assert.assertEquals(6, allConfigs.size());
+    }
+
+    @Test
+    public void canCollectAllProjectConfigCreatedFrom()
+    {
+        List<StoreProjectVersionData> allConfigs = projectsVersionsAPI.findByCreationDate(1687227600000L,
+                toTime(LocalDateTime.now()));
+        Assert.assertNotNull(allConfigs);
+        Assert.assertEquals(3, allConfigs.size());
+    }
+
+    @Test
+    public void canCollectAllProjectConfigCreatedFromTo()
+    {
+        List<StoreProjectVersionData> allConfigs = projectsVersionsAPI.findByCreationDate(1687219200000L, 1687219210000L);
+        Assert.assertNotNull(allConfigs);
+        Assert.assertEquals(1, allConfigs.size());
     }
 
     @Test

--- a/legend-depot-core-data-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/projects/TestQueryProjectVersionApi.java
+++ b/legend-depot-core-data-store-mongo/src/test/java/org/finos/legend/depot/store/mongo/projects/TestQueryProjectVersionApi.java
@@ -48,18 +48,18 @@ public class TestQueryProjectVersionApi extends CoreDataMongoStoreTests
     }
 
     @Test
-    public void canCollectAllProjectConfigCreatedFrom()
+    public void canCollectAllProjectConfigUpdatedFrom()
     {
-        List<StoreProjectVersionData> allConfigs = projectsVersionsAPI.findByCreationDate(1687227600000L,
+        List<StoreProjectVersionData> allConfigs = projectsVersionsAPI.findByUpdatedDate(1687227600000L,
                 toTime(LocalDateTime.now()));
         Assert.assertNotNull(allConfigs);
         Assert.assertEquals(3, allConfigs.size());
     }
 
     @Test
-    public void canCollectAllProjectConfigCreatedFromTo()
+    public void canCollectAllProjectConfigUpdatedFromTo()
     {
-        List<StoreProjectVersionData> allConfigs = projectsVersionsAPI.findByCreationDate(1687219200000L, 1687219210000L);
+        List<StoreProjectVersionData> allConfigs = projectsVersionsAPI.findByUpdatedDate(1687219200000L, 1687219210000L);
         Assert.assertNotNull(allConfigs);
         Assert.assertEquals(1, allConfigs.size());
     }

--- a/legend-depot-core-data-store-mongo/src/test/resources/data/projectsVersions.json
+++ b/legend-depot-core-data-store-mongo/src/test/resources/data/projectsVersions.json
@@ -3,13 +3,13 @@
     "groupId": "examples.metadata",
     "artifactId": "test",
     "versionId": "2.2.0",
-    "creationDate": "2023-04-20"
+    "updated": "2023-04-20"
   },
   {
     "groupId": "examples.metadata",
     "artifactId": "test",
     "versionId": "master-SNAPSHOT",
-    "creationDate": "2023-05-20",
+    "updated": "2023-05-20",
     "versionData": {
       "dependencies": [
         {
@@ -24,7 +24,7 @@
     "groupId": "examples.metadata",
     "artifactId": "test",
     "versionId": "3.0.0",
-    "creationDate": "2023-06-20",
+    "updated": "2023-06-20",
     "versionData": {
       "excluded": "true",
       "exclusionReason": "version could not be loaded"
@@ -34,7 +34,7 @@
     "groupId": "examples.metadata",
     "artifactId": "test",
     "versionId": "2.3.1",
-    "creationDate": "2023-09-20",
+    "updated": "2023-09-20",
     "versionData": {
       "dependencies": [
         {
@@ -53,12 +53,13 @@
     "groupId": "examples.metadata",
     "artifactId": "test-dependencies",
     "versionId": "1.0.0",
-    "creationDate": "2023-07-20"
+    "updated": "2023-07-20"
+
   },
   {
     "groupId": "example.services.test",
     "artifactId": "test",
     "versionId": "2.0.1",
-    "creationDate": "2023-08-20"
+    "updated": "2023-08-20"
   }
 ]

--- a/legend-depot-core-data-store-mongo/src/test/resources/data/projectsVersions.json
+++ b/legend-depot-core-data-store-mongo/src/test/resources/data/projectsVersions.json
@@ -2,12 +2,14 @@
   {
     "groupId": "examples.metadata",
     "artifactId": "test",
-    "versionId": "2.2.0"
+    "versionId": "2.2.0",
+    "creationDate": "2023-04-20"
   },
   {
     "groupId": "examples.metadata",
     "artifactId": "test",
     "versionId": "master-SNAPSHOT",
+    "creationDate": "2023-05-20",
     "versionData": {
       "dependencies": [
         {
@@ -22,6 +24,7 @@
     "groupId": "examples.metadata",
     "artifactId": "test",
     "versionId": "3.0.0",
+    "creationDate": "2023-06-20",
     "versionData": {
       "excluded": "true",
       "exclusionReason": "version could not be loaded"
@@ -31,6 +34,7 @@
     "groupId": "examples.metadata",
     "artifactId": "test",
     "versionId": "2.3.1",
+    "creationDate": "2023-09-20",
     "versionData": {
       "dependencies": [
         {
@@ -48,11 +52,13 @@
   {
     "groupId": "examples.metadata",
     "artifactId": "test-dependencies",
-    "versionId": "1.0.0"
+    "versionId": "1.0.0",
+    "creationDate": "2023-07-20"
   },
   {
     "groupId": "example.services.test",
     "artifactId": "test",
-    "versionId": "2.0.1"
+    "versionId": "2.0.1",
+    "creationDate": "2023-08-20"
   }
 ]

--- a/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/core/services/tracing/ResourceLoggingAndTracing.java
+++ b/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/core/services/tracing/ResourceLoggingAndTracing.java
@@ -18,6 +18,7 @@ package org.finos.legend.depot.core.services.tracing;
 public class ResourceLoggingAndTracing
 {
     public static final String GET_ALL_PROJECTS = "get all projects";
+    public static final String GET_VERSIONS_BY_CREATION_DATE = "get versions by creation date";
     public static final String GET_PROJECT_CONFIG_BY_GA = "get project configuration by ga";
     public static final String FIND_PROJECT_VERSIONS = "find project versions";
     public static final String GET_PROJECT_VERSION_BY_GAV = "get project version by gav";

--- a/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/core/services/tracing/ResourceLoggingAndTracing.java
+++ b/legend-depot-core-tracing/src/main/java/org/finos/legend/depot/core/services/tracing/ResourceLoggingAndTracing.java
@@ -18,7 +18,7 @@ package org.finos.legend.depot.core.services.tracing;
 public class ResourceLoggingAndTracing
 {
     public static final String GET_ALL_PROJECTS = "get all projects";
-    public static final String GET_VERSIONS_BY_CREATION_DATE = "get versions by creation date";
+    public static final String GET_VERSIONS_BY_LASTUPDATE_DATE = "get versions by lastupdate date";
     public static final String GET_PROJECT_CONFIG_BY_GA = "get project configuration by ga";
     public static final String FIND_PROJECT_VERSIONS = "find project versions";
     public static final String GET_PROJECT_VERSION_BY_GAV = "get project version by gav";


### PR DESCRIPTION
New Projects Versions Endpoint

/projects/versions/{createdFrom time in UTC milliseconds}?{createdTo end time in milliseconds in UTC}

to query for changed versions from a created from time limited possible by a created to time to enable querying for continuous change streams over time thereby reducing return load on the depot server as well as reducing processing for the client.

The times are specified in milliseconds and will be treated as UTC timestamps