### PR TITLE
Add maven source plugin and execution id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,20 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.2.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <phase>install</phase>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven.dependency.plugin.version}</version>
                 </plugin>


### PR DESCRIPTION
Add maven source plugin and execution id to be consistent with config brought in via maven-model-builder
Execution IDs of maven-source-plugin need to be consistent to avoid duplicate uploads of source artefacts