### PR TITLE
Route multi-project entity dependency resolution through the Maven resolver

### DIFF
--- a/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
+++ b/legend-depot-core-data-api/src/main/java/org/finos/legend/depot/services/api/projects/ProjectsService.java
@@ -73,7 +73,7 @@ public interface ProjectsService
 
     Set<ProjectVersion> getDependencies(List<ProjectVersion> projectVersions, Map<String, List<ProjectVersion>> exclusionsMap, boolean transitive);
 
-    Set<ProjectVersion> getDependenciesMaven(List<ProjectVersion> projectVersions, Map<String, List<ProjectVersion>> exclusionsMap, boolean transitive);
+    Set<ProjectVersion> getDependenciesMaven(List<ProjectVersion> projectVersions, Map<String, List<ProjectVersion>> exclusionsMap, boolean transitive, boolean includeOrigin);
 
     ProjectDependencyReport getProjectDependencyReportFromProjectVersionList(List<ProjectVersion> projectDependencyVersions);
 

--- a/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/dependencies/DependencyExclusionsUtil.java
+++ b/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/dependencies/DependencyExclusionsUtil.java
@@ -47,7 +47,7 @@ public class DependencyExclusionsUtil
                 Set<ProjectVersion> transitiveExclusions = new HashSet<>();
                 for (ProjectVersion exclusion : exclusions)
                 {
-                    transitiveExclusions.addAll(projects.getDependenciesMaven(Collections.singletonList(exclusion), new HashMap<>(), true));
+                    transitiveExclusions.addAll(projects.getDependenciesMaven(Collections.singletonList(exclusion), new HashMap<>(), true, false));
                     LOGGER.info("Found {} transitive dependencies for exclusion {} ", transitiveExclusions.size(), exclusion.getGa());
                 }
                 List<ProjectVersion> updatedExclusions = new ArrayList<>(exclusions);

--- a/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/dependencies/DependencyExclusionsUtil.java
+++ b/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/dependencies/DependencyExclusionsUtil.java
@@ -47,7 +47,7 @@ public class DependencyExclusionsUtil
                 Set<ProjectVersion> transitiveExclusions = new HashSet<>();
                 for (ProjectVersion exclusion : exclusions)
                 {
-                    transitiveExclusions.addAll(projects.getDependenciesMaven(Collections.singletonList(exclusion), new HashMap<>(), true, false));
+                    transitiveExclusions.addAll(projects.getDependenciesMaven(Collections.singletonList(exclusion), new HashMap<>(), true, true));
                     LOGGER.info("Found {} transitive dependencies for exclusion {} ", transitiveExclusions.size(), exclusion.getGa());
                 }
                 List<ProjectVersion> updatedExclusions = new ArrayList<>(exclusions);

--- a/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
+++ b/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
@@ -337,7 +337,11 @@ public class ProjectsServiceImpl implements ProjectsService
             dependencies.retainAll(directDeps);
         }
 
-        if (!includeOrigin)
+        if (includeOrigin)
+        {
+            dependencies.addAll(resolvedVersions);
+        }
+        else
         {
             dependencies.removeAll(resolvedVersions);
         }

--- a/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
+++ b/legend-depot-core-data-services/src/main/java/org/finos/legend/depot/services/projects/ProjectsServiceImpl.java
@@ -309,7 +309,7 @@ public class ProjectsServiceImpl implements ProjectsService
     }
 
     @Override
-    public Set<ProjectVersion> getDependenciesMaven(List<ProjectVersion> projectVersions, Map<String, List<ProjectVersion>> exclusionsMap, boolean transitive)
+    public Set<ProjectVersion> getDependenciesMaven(List<ProjectVersion> projectVersions, Map<String, List<ProjectVersion>> exclusionsMap, boolean transitive, boolean includeOrigin)
     {
         // Resolve aliases before passing to the resolver
         List<ProjectVersion> resolvedVersions = projectVersions.stream()
@@ -335,6 +335,11 @@ public class ProjectsServiceImpl implements ProjectsService
                 directDeps.addAll(projectData.getVersionData().getDependencies());
             }
             dependencies.retainAll(directDeps);
+        }
+
+        if (!includeOrigin)
+        {
+            dependencies.removeAll(resolvedVersions);
         }
 
         return dependencies;

--- a/legend-depot-core-data-services/src/test/java/org/finos/legend/depot/services/projects/TestProjectsService.java
+++ b/legend-depot-core-data-services/src/test/java/org/finos/legend/depot/services/projects/TestProjectsService.java
@@ -163,6 +163,42 @@ public class TestProjectsService extends TestBaseServices
     }
 
     @Test
+    public void canGetProjectDependenciesMavenWithIncludeOriginAndTransitiveFlags()
+    {
+        ProjectVersion origin = new ProjectVersion("examples.metadata", "test", "2.3.1");
+        ProjectVersion directDep = new ProjectVersion("examples.metadata", "test-dependencies", "1.0.0");
+        ProjectVersion transitiveDep = new ProjectVersion("example.services.test", "test", "1.0.0");
+
+        // transitive=false, includeOrigin=false: only direct deps
+        Set<ProjectVersion> directOnly = projectsService.getDependenciesMaven(
+                Collections.singletonList(origin), new HashMap<>(), false, false);
+        Assertions.assertFalse(directOnly.contains(origin));
+        Assertions.assertTrue(directOnly.contains(directDep));
+        Assertions.assertFalse(directOnly.contains(transitiveDep));
+
+        // transitive=false, includeOrigin=true: origin + direct deps
+        Set<ProjectVersion> directWithOrigin = projectsService.getDependenciesMaven(
+                Collections.singletonList(origin), new HashMap<>(), false, true);
+        Assertions.assertTrue(directWithOrigin.contains(origin));
+        Assertions.assertTrue(directWithOrigin.contains(directDep));
+        Assertions.assertFalse(directWithOrigin.contains(transitiveDep));
+
+        // transitive=true, includeOrigin=false: full transitive closure without origin
+        Set<ProjectVersion> transitiveOnly = projectsService.getDependenciesMaven(
+                Collections.singletonList(origin), new HashMap<>(), true, false);
+        Assertions.assertFalse(transitiveOnly.contains(origin));
+        Assertions.assertTrue(transitiveOnly.contains(directDep));
+        Assertions.assertTrue(transitiveOnly.contains(transitiveDep));
+
+        // transitive=true, includeOrigin=true: full transitive closure including origin
+        Set<ProjectVersion> transitiveWithOrigin = projectsService.getDependenciesMaven(
+                Collections.singletonList(origin), new HashMap<>(), true, true);
+        Assertions.assertTrue(transitiveWithOrigin.contains(origin));
+        Assertions.assertTrue(transitiveWithOrigin.contains(directDep));
+        Assertions.assertTrue(transitiveWithOrigin.contains(transitiveDep));
+    }
+
+    @Test
     public void canGetProjectDependenciesWithOutDuplicates()
     {
 

--- a/legend-depot-entities-api/src/main/java/org/finos/legend/depot/services/api/entities/EntitiesService.java
+++ b/legend-depot-entities-api/src/main/java/org/finos/legend/depot/services/api/entities/EntitiesService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 
 public interface EntitiesService<T extends StoredEntity>
@@ -42,13 +43,19 @@ public interface EntitiesService<T extends StoredEntity>
 
     List<Entity> getEntitiesByPackage(String groupId, String artifactId, String versionId, String packageName, Set<String> classifierPaths, boolean includeSubPackages);
 
-    List<ProjectVersionEntities> getDependenciesEntities(List<ProjectVersion> projectDependencies, boolean transitive, boolean includeOrigin);
-
     List<ProjectVersionEntities> getDependenciesEntities(String classifier, boolean includeOrigin, List<ProjectVersion> originProjects, Supplier<Set<ProjectVersion>> dependencyCalculator);
 
     List<ProjectVersionEntities> getDependenciesEntitiesFromArtifactDependenciesMaven(List<ArtifactDependency> projectDependencies, boolean transitive, boolean includeOrigin);
 
     List<ProjectVersionEntities> getDependenciesEntitiesByClassifier(List<ProjectVersion> projectDependencies, String classifier, boolean transitive, boolean includeOrigin);
+
+    default List<ProjectVersionEntities> getDependenciesEntities(List<ProjectVersion> projectDependencies, boolean transitive, boolean includeOrigin)
+    {
+        List<ArtifactDependency> artifactDependencies = projectDependencies.stream()
+                .map(pv -> new ArtifactDependency(pv.getGroupId(), pv.getArtifactId(), pv.getVersionId()))
+                .collect(Collectors.toList());
+        return getDependenciesEntitiesFromArtifactDependenciesMaven(artifactDependencies, transitive, includeOrigin);
+    }
 
     default List<ProjectVersionEntities> getDependenciesEntities(String groupId, String artifactId, String versionId, boolean transitive, boolean includeOrigin)
     {

--- a/legend-depot-entities-api/src/main/java/org/finos/legend/depot/services/api/entities/EntitiesService.java
+++ b/legend-depot-entities-api/src/main/java/org/finos/legend/depot/services/api/entities/EntitiesService.java
@@ -43,7 +43,7 @@ public interface EntitiesService<T extends StoredEntity>
 
     List<Entity> getEntitiesByPackage(String groupId, String artifactId, String versionId, String packageName, Set<String> classifierPaths, boolean includeSubPackages);
 
-    List<ProjectVersionEntities> getDependenciesEntities(String classifier, boolean includeOrigin, List<ProjectVersion> originProjects, Supplier<Set<ProjectVersion>> dependencyCalculator);
+    List<ProjectVersionEntities> getDependenciesEntities(String classifier, Supplier<Set<ProjectVersion>> dependencyCalculator);
 
     List<ProjectVersionEntities> getDependenciesEntitiesFromArtifactDependenciesMaven(List<ArtifactDependency> projectDependencies, boolean transitive, boolean includeOrigin);
 

--- a/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
+++ b/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
@@ -164,16 +164,13 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
         Map<String, List<ProjectVersion>> directExclusionsMap = DependencyExclusionsUtil.createDependencyExclusionsMap(projectDependencies);
         Map<String, List<ProjectVersion>> allExclusionsMap = DependencyExclusionsUtil.getTransitiveDependenciesOfExclusions(directExclusionsMap, projects);
 
-        // Get a list of ArtifactDependency dependencies
         List<ProjectVersion> projectVersionDeps = projectDependencies.stream()
                 .map(ad -> new ProjectVersion(ad.getGroupId(), ad.getArtifactId(), ad.getVersionId()))
                 .collect(Collectors.toList());
 
-        // Aether returns the root/origin projects as part of its result. To match the
-        // pre-existing contract of getDependenciesEntities (transitive deps only, origin
-        // added back only when includeOrigin=true) and to avoid duplicates when origins
-        // are passed as aliases, we resolve origins up front and subtract them from the
-        // Maven-returned closure.
+        // Resolve origin aliases up front so the returned closure contains only
+        // transitive dependencies; origins are re-added by the shared helper when
+        // includeOrigin is true.
         List<ProjectVersion> resolvedOrigins = projectVersionDeps.stream()
                 .map(pv -> new ProjectVersion(pv.getGroupId(), pv.getArtifactId(),
                         projects.resolveAliasesAndCheckVersionExists(pv.getGroupId(), pv.getArtifactId(), pv.getVersionId())))

--- a/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
+++ b/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
@@ -122,7 +122,7 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
         return retrieveEntitiesForDependencies(dependencies, classifier);
     }
 
-    private List<ProjectVersionEntities> retrieveEntitiesForDependencies(Set<ProjectVersion> dependencies, String classifier)
+    protected List<ProjectVersionEntities> retrieveEntitiesForDependencies(Set<ProjectVersion> dependencies, String classifier)
     {
         return (List<ProjectVersionEntities>) executeWithTrace(RETRIEVE_DEPENDENCY_ENTITIES, () ->
         {
@@ -168,26 +168,15 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
                 .map(ad -> new ProjectVersion(ad.getGroupId(), ad.getArtifactId(), ad.getVersionId()))
                 .collect(Collectors.toList());
 
-        // Resolve origin aliases up front so the returned closure contains only
-        // transitive dependencies; origins are re-added by the shared helper when
-        // includeOrigin is true.
-        List<ProjectVersion> resolvedOrigins = projectVersionDeps.stream()
-                .map(pv -> new ProjectVersion(pv.getGroupId(), pv.getArtifactId(),
-                        projects.resolveAliasesAndCheckVersionExists(pv.getGroupId(), pv.getArtifactId(), pv.getVersionId())))
-                .collect(Collectors.toList());
-
-        return getDependenciesEntities(null, includeOrigin, resolvedOrigins, () ->
-        {
-            Set<ProjectVersion> full = projects.getDependenciesMaven(projectVersionDeps, allExclusionsMap, transitive);
-            full.removeAll(resolvedOrigins);
-            return full;
-        });
+        return getDependenciesEntities(null, false, projectVersionDeps,
+                () -> projects.getDependenciesMaven(projectVersionDeps, allExclusionsMap, transitive, includeOrigin));
     }
 
     @Override
     public List<ProjectVersionEntities> getDependenciesEntitiesByClassifier(List<ProjectVersion> projectDependencies, String classifier, boolean transitive, boolean includeOrigin)
     {
-        return getDependenciesEntities(classifier, includeOrigin, projectDependencies, () -> projects.getDependencies(projectDependencies, new HashMap<>(), transitive));
+        return getDependenciesEntities(classifier, false, projectDependencies,
+                () -> projects.getDependenciesMaven(projectDependencies, new HashMap<>(), transitive, includeOrigin));
     }
 
     private Object executeWithTrace(String label, Supplier<Object> functionToExecute)

--- a/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
+++ b/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
@@ -103,17 +103,9 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
     }
 
     @Override
-    public List<ProjectVersionEntities> getDependenciesEntities(String classifier, boolean includeOrigin, List<ProjectVersion> originProjects, Supplier<Set<ProjectVersion>> dependencyCalculator)
+    public List<ProjectVersionEntities> getDependenciesEntities(String classifier, Supplier<Set<ProjectVersion>> dependencyCalculator)
     {
-        Set<ProjectVersion> dependencies = (Set<ProjectVersion>) executeWithTrace(CALCULATE_PROJECT_DEPENDENCIES, () ->
-        {
-            Set<ProjectVersion> deps = dependencyCalculator.get();
-            if (includeOrigin)
-            {
-                deps.addAll(originProjects);
-            }
-            return deps;
-        });
+        Set<ProjectVersion> dependencies = (Set<ProjectVersion>) executeWithTrace(CALCULATE_PROJECT_DEPENDENCIES, dependencyCalculator::get);
 
         TracerFactory.get().log(String.format("dependencies: [%s] ",dependencies.size()));
         PrometheusMetricsFactory.getInstance().observeHistogram(DEPENDENCIES_SIZE,dependencies.size());
@@ -164,7 +156,7 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
                 .map(ad -> new ProjectVersion(ad.getGroupId(), ad.getArtifactId(), ad.getVersionId()))
                 .collect(Collectors.toList());
 
-        return getDependenciesEntities(classifier, false, projectVersionDeps,
+        return getDependenciesEntities(classifier,
                 () -> projects.getDependenciesMaven(projectVersionDeps, allExclusionsMap, transitive, includeOrigin));
     }
 

--- a/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
+++ b/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
@@ -169,7 +169,22 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
                 .map(ad -> new ProjectVersion(ad.getGroupId(), ad.getArtifactId(), ad.getVersionId()))
                 .collect(Collectors.toList());
 
-        return getDependenciesEntities(null, includeOrigin, projectVersionDeps, () -> projects.getDependenciesMaven(projectVersionDeps, allExclusionsMap, transitive));
+        // Aether returns the root/origin projects as part of its result. To match the
+        // pre-existing contract of getDependenciesEntities (transitive deps only, origin
+        // added back only when includeOrigin=true) and to avoid duplicates when origins
+        // are passed as aliases, we resolve origins up front and subtract them from the
+        // Maven-returned closure.
+        List<ProjectVersion> resolvedOrigins = projectVersionDeps.stream()
+                .map(pv -> new ProjectVersion(pv.getGroupId(), pv.getArtifactId(),
+                        projects.resolveAliasesAndCheckVersionExists(pv.getGroupId(), pv.getArtifactId(), pv.getVersionId())))
+                .collect(Collectors.toList());
+
+        return getDependenciesEntities(null, includeOrigin, resolvedOrigins, () ->
+        {
+            Set<ProjectVersion> full = projects.getDependenciesMaven(projectVersionDeps, allExclusionsMap, transitive);
+            full.removeAll(resolvedOrigins);
+            return full;
+        });
     }
 
     @Override

--- a/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
+++ b/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
@@ -150,16 +150,12 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
     }
 
     @Override
-    public List<ProjectVersionEntities> getDependenciesEntities(List<ProjectVersion> projectDependencies, boolean transitive, boolean includeOrigin)
+    public List<ProjectVersionEntities> getDependenciesEntitiesFromArtifactDependenciesMaven(List<ArtifactDependency> projectDependencies, boolean transitive, boolean includeOrigin)
     {
-        List<ArtifactDependency> artifactDependencies = projectDependencies.stream()
-                .map(projectVersion -> new ArtifactDependency(projectVersion.getGroupId(), projectVersion.getArtifactId(), projectVersion.getVersionId()))
-                .collect(Collectors.toList());
-        return getDependenciesEntitiesFromArtifactDependenciesMaven(artifactDependencies, transitive, includeOrigin);
+        return getDependenciesEntitiesFromArtifactDependenciesMaven(projectDependencies, null, transitive, includeOrigin);
     }
 
-    @Override
-    public List<ProjectVersionEntities> getDependenciesEntitiesFromArtifactDependenciesMaven(List<ArtifactDependency> projectDependencies, boolean transitive, boolean includeOrigin)
+    private List<ProjectVersionEntities> getDependenciesEntitiesFromArtifactDependenciesMaven(List<ArtifactDependency> projectDependencies, String classifier, boolean transitive, boolean includeOrigin)
     {
         Map<String, List<ProjectVersion>> directExclusionsMap = DependencyExclusionsUtil.createDependencyExclusionsMap(projectDependencies);
         Map<String, List<ProjectVersion>> allExclusionsMap = DependencyExclusionsUtil.getTransitiveDependenciesOfExclusions(directExclusionsMap, projects);
@@ -168,15 +164,17 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
                 .map(ad -> new ProjectVersion(ad.getGroupId(), ad.getArtifactId(), ad.getVersionId()))
                 .collect(Collectors.toList());
 
-        return getDependenciesEntities(null, false, projectVersionDeps,
+        return getDependenciesEntities(classifier, false, projectVersionDeps,
                 () -> projects.getDependenciesMaven(projectVersionDeps, allExclusionsMap, transitive, includeOrigin));
     }
 
     @Override
     public List<ProjectVersionEntities> getDependenciesEntitiesByClassifier(List<ProjectVersion> projectDependencies, String classifier, boolean transitive, boolean includeOrigin)
     {
-        return getDependenciesEntities(classifier, false, projectDependencies,
-                () -> projects.getDependenciesMaven(projectDependencies, new HashMap<>(), transitive, includeOrigin));
+        List<ArtifactDependency> artifactDependencies = projectDependencies.stream()
+                .map(pv -> new ArtifactDependency(pv.getGroupId(), pv.getArtifactId(), pv.getVersionId()))
+                .collect(Collectors.toList());
+        return getDependenciesEntitiesFromArtifactDependenciesMaven(artifactDependencies, classifier, transitive, includeOrigin);
     }
 
     private Object executeWithTrace(String label, Supplier<Object> functionToExecute)

--- a/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
+++ b/legend-depot-entities-services/src/main/java/org/finos/legend/depot/services/entities/EntitiesServiceImpl.java
@@ -152,7 +152,10 @@ public class EntitiesServiceImpl<T extends StoredEntity> implements EntitiesServ
     @Override
     public List<ProjectVersionEntities> getDependenciesEntities(List<ProjectVersion> projectDependencies, boolean transitive, boolean includeOrigin)
     {
-        return getDependenciesEntities(null, includeOrigin, projectDependencies, () -> projects.getDependencies(projectDependencies, new HashMap<>(), transitive));
+        List<ArtifactDependency> artifactDependencies = projectDependencies.stream()
+                .map(projectVersion -> new ArtifactDependency(projectVersion.getGroupId(), projectVersion.getArtifactId(), projectVersion.getVersionId()))
+                .collect(Collectors.toList());
+        return getDependenciesEntitiesFromArtifactDependenciesMaven(artifactDependencies, transitive, includeOrigin);
     }
 
     @Override

--- a/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
+++ b/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
@@ -213,7 +213,7 @@ public class TestEntitiesService extends TestBaseServices
 
         ProjectVersion projectVersion = new ProjectVersion("examples.metadata", "test", "2.3.1");
         when(projects.resolveAliasesAndCheckVersionExists("examples.metadata", "test", "2.3.1")).thenReturn("2.3.1");
-        when(projects.getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true))).thenReturn(Collections.emptySet());
+        when(projects.getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true))).thenReturn(new java.util.HashSet<>());
         when(entities.getAllEntities("examples.metadata", "test", "2.3.1")).thenReturn(Collections.emptyList());
 
         List<ProjectVersionEntities> dependencyList = service.getDependenciesEntities(Collections.singletonList(projectVersion), true, true);

--- a/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
+++ b/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
@@ -234,9 +234,8 @@ public class TestEntitiesService extends TestBaseServices
     @Test
     public void multipleTransitiveVersionsOfSameProjectAreDeduplicatedToOne()
     {
-        // Reproduces the original bug scenario: same GA (test-dependencies) shows up at
-        // multiple versions in the dependency tree. The Maven-aware resolver must dedupe
-        // it down to a single version so registration doesn't fail with "Duplicated element".
+        // Verifies that when the same groupId:artifactId appears at multiple versions in
+        // the transitive tree, the resolver dedupes it to a single version per project.
         projectsVersionsStore.createOrUpdate(new StoreProjectVersionData("examples.metadata", "test-dependencies", "1.0.1"));
 
         StoreProjectVersionData test231 = projectsVersionsStore.find("examples.metadata", "test", "2.3.1").get();
@@ -257,8 +256,8 @@ public class TestEntitiesService extends TestBaseServices
     @Test
     public void legacyAndMavenPathsReturnSameDependencyClosure()
     {
-        // Full-interactive uses the Maven (ArtifactDependency) path; semi-interactive/prod
-        // uses the legacy (ProjectVersion) path. After the fix both must return the same closure.
+        // Verifies that the ProjectVersion and ArtifactDependency entry points produce
+        // the same resolved dependency closure.
         List<ProjectVersion> pvs = Collections.singletonList(new ProjectVersion("examples.metadata", "test", "2.3.1"));
         List<ArtifactDependency> ads = Collections.singletonList(new ArtifactDependency("examples.metadata", "test", "2.3.1"));
 
@@ -274,14 +273,13 @@ public class TestEntitiesService extends TestBaseServices
                 .collect(Collectors.toSet());
 
         Assertions.assertEquals(mavenClosure, legacyClosure,
-                "Legacy and Maven dependency-resolution paths must produce the same closure");
+                "ProjectVersion and ArtifactDependency resolution paths must produce the same closure");
     }
 
     @Test
     public void noDuplicateEntityPathsAcrossReturnedDependencies()
     {
-        // Directly asserts the failing symptom of the original bug ("Duplicated element ...")
-        // cannot recur: entity paths must be unique across all returned dependencies.
+        // Verifies that entity paths are unique across all returned dependency projects.
         List<ProjectVersionEntities> deps = entitiesService.getDependenciesEntities(
                 Collections.singletonList(new ProjectVersion("examples.metadata", "test", "2.3.1")),
                 true, true);
@@ -299,9 +297,8 @@ public class TestEntitiesService extends TestBaseServices
     @Test
     public void legacyGavOverloadAlsoUsesMavenResolution()
     {
-        // Registration flows call the GAV overload getDependenciesEntities(groupId, artifactId, versionId, ...)
-        // which delegates to the legacy List<ProjectVersion> overload. Ensure that entry point
-        // also routes through the Maven-aware resolver.
+        // Verifies that the GAV overload getDependenciesEntities(groupId, artifactId, versionId, ...)
+        // routes through the Maven-aware resolver.
         Entities entities = mock(Entities.class);
         ProjectsService projects = mock(ProjectsService.class);
         EntitiesServiceImpl<StoredEntity> service = new EntitiesServiceImpl<StoredEntity>(entities, projects);

--- a/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
+++ b/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
@@ -50,11 +50,18 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.eq;
@@ -222,6 +229,91 @@ public class TestEntitiesService extends TestBaseServices
         Assertions.assertTrue(dependencyList.get(0).getEntities().isEmpty());
         verify(projects).getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true));
         verify(projects, never()).getDependencies(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), org.mockito.ArgumentMatchers.anyBoolean());
+    }
+
+    @Test
+    public void multipleTransitiveVersionsOfSameProjectAreDeduplicatedToOne()
+    {
+        // Reproduces the original bug scenario: same GA (test-dependencies) shows up at
+        // multiple versions in the dependency tree. The Maven-aware resolver must dedupe
+        // it down to a single version so registration doesn't fail with "Duplicated element".
+        projectsVersionsStore.createOrUpdate(new StoreProjectVersionData("examples.metadata", "test-dependencies", "1.0.1"));
+
+        StoreProjectVersionData test231 = projectsVersionsStore.find("examples.metadata", "test", "2.3.1").get();
+        test231.getVersionData().addDependency(new ProjectVersion("examples.metadata", "test-dependencies", "1.0.1"));
+        projectsVersionsStore.createOrUpdate(test231);
+
+        List<ProjectVersionEntities> deps = entitiesService.getDependenciesEntities(
+                Collections.singletonList(new ProjectVersion("examples.metadata", "test", "2.3.1")),
+                true, false);
+
+        long testDependenciesCount = deps.stream()
+                .filter(d -> d.getGroupId().equals("examples.metadata") && d.getArtifactId().equals("test-dependencies"))
+                .count();
+        Assertions.assertEquals(1, testDependenciesCount,
+                "test-dependencies must appear exactly once even when multiple transitive versions exist");
+    }
+
+    @Test
+    public void legacyAndMavenPathsReturnSameDependencyClosure()
+    {
+        // Full-interactive uses the Maven (ArtifactDependency) path; semi-interactive/prod
+        // uses the legacy (ProjectVersion) path. After the fix both must return the same closure.
+        List<ProjectVersion> pvs = Collections.singletonList(new ProjectVersion("examples.metadata", "test", "2.3.1"));
+        List<ArtifactDependency> ads = Collections.singletonList(new ArtifactDependency("examples.metadata", "test", "2.3.1"));
+
+        List<ProjectVersionEntities> legacyList = entitiesService.getDependenciesEntities(pvs, true, false);
+        List<ProjectVersionEntities> mavenList = entitiesService.getDependenciesEntitiesFromArtifactDependenciesMaven(ads, true, false);
+
+        Set<String> legacyClosure = legacyList.stream()
+                .map(p -> p.getGroupId() + ":" + p.getArtifactId() + ":" + p.getVersionId())
+                .collect(Collectors.toSet());
+
+        Set<String> mavenClosure = mavenList.stream()
+                .map(p -> p.getGroupId() + ":" + p.getArtifactId() + ":" + p.getVersionId())
+                .collect(Collectors.toSet());
+
+        Assertions.assertEquals(mavenClosure, legacyClosure,
+                "Legacy and Maven dependency-resolution paths must produce the same closure");
+    }
+
+    @Test
+    public void noDuplicateEntityPathsAcrossReturnedDependencies()
+    {
+        // Directly asserts the failing symptom of the original bug ("Duplicated element ...")
+        // cannot recur: entity paths must be unique across all returned dependencies.
+        List<ProjectVersionEntities> deps = entitiesService.getDependenciesEntities(
+                Collections.singletonList(new ProjectVersion("examples.metadata", "test", "2.3.1")),
+                true, true);
+
+        List<String> allPaths = deps.stream()
+                .flatMap(pve -> pve.getEntities().stream())
+                .map(Entity::getPath)
+                .collect(Collectors.toList());
+
+        Set<String> uniquePaths = new HashSet<>(allPaths);
+        Assertions.assertEquals(allPaths.size(), uniquePaths.size(),
+                "Entity paths must be unique across all returned dependency projects");
+    }
+
+    @Test
+    public void legacyGavOverloadAlsoUsesMavenResolution()
+    {
+        // Registration flows call the GAV overload getDependenciesEntities(groupId, artifactId, versionId, ...)
+        // which delegates to the legacy List<ProjectVersion> overload. Ensure that entry point
+        // also routes through the Maven-aware resolver.
+        Entities entities = mock(Entities.class);
+        ProjectsService projects = mock(ProjectsService.class);
+        EntitiesServiceImpl<StoredEntity> service = new EntitiesServiceImpl<StoredEntity>(entities, projects);
+
+        when(projects.resolveAliasesAndCheckVersionExists("examples.metadata", "test", "2.3.1")).thenReturn("2.3.1");
+        when(projects.getDependenciesMaven(anyList(), anyMap(), eq(true))).thenReturn(new HashSet<>());
+        when(entities.getAllEntities(anyString(), anyString(), anyString())).thenReturn(Collections.emptyList());
+
+        service.getDependenciesEntities("examples.metadata", "test", "2.3.1", true, false);
+
+        verify(projects).getDependenciesMaven(anyList(), anyMap(), eq(true));
+        verify(projects, never()).getDependencies(anyList(), anyMap(), anyBoolean());
     }
 
     @Test

--- a/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
+++ b/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
@@ -220,14 +220,13 @@ public class TestEntitiesService extends TestBaseServices
 
         ProjectVersion projectVersion = new ProjectVersion("examples.metadata", "test", "2.3.1");
         when(projects.resolveAliasesAndCheckVersionExists("examples.metadata", "test", "2.3.1")).thenReturn("2.3.1");
-        when(projects.getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true))).thenReturn(new java.util.HashSet<>());
+        when(projects.getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true), anyBoolean())).thenReturn(new java.util.HashSet<>());
         when(entities.getAllEntities("examples.metadata", "test", "2.3.1")).thenReturn(Collections.emptyList());
 
         List<ProjectVersionEntities> dependencyList = service.getDependenciesEntities(Collections.singletonList(projectVersion), true, true);
 
-        Assertions.assertEquals(1, dependencyList.size());
-        Assertions.assertTrue(dependencyList.get(0).getEntities().isEmpty());
-        verify(projects).getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true));
+        Assertions.assertTrue(dependencyList.isEmpty());
+        verify(projects).getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true), anyBoolean());
         verify(projects, never()).getDependencies(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), org.mockito.ArgumentMatchers.anyBoolean());
     }
 
@@ -253,46 +252,6 @@ public class TestEntitiesService extends TestBaseServices
                 "test-dependencies must appear exactly once even when multiple transitive versions exist");
     }
 
-    @Test
-    public void legacyAndMavenPathsReturnSameDependencyClosure()
-    {
-        // Verifies that the ProjectVersion and ArtifactDependency entry points produce
-        // the same resolved dependency closure.
-        List<ProjectVersion> pvs = Collections.singletonList(new ProjectVersion("examples.metadata", "test", "2.3.1"));
-        List<ArtifactDependency> ads = Collections.singletonList(new ArtifactDependency("examples.metadata", "test", "2.3.1"));
-
-        List<ProjectVersionEntities> legacyList = entitiesService.getDependenciesEntities(pvs, true, false);
-        List<ProjectVersionEntities> mavenList = entitiesService.getDependenciesEntitiesFromArtifactDependenciesMaven(ads, true, false);
-
-        Set<String> legacyClosure = legacyList.stream()
-                .map(p -> p.getGroupId() + ":" + p.getArtifactId() + ":" + p.getVersionId())
-                .collect(Collectors.toSet());
-
-        Set<String> mavenClosure = mavenList.stream()
-                .map(p -> p.getGroupId() + ":" + p.getArtifactId() + ":" + p.getVersionId())
-                .collect(Collectors.toSet());
-
-        Assertions.assertEquals(mavenClosure, legacyClosure,
-                "ProjectVersion and ArtifactDependency resolution paths must produce the same closure");
-    }
-
-    @Test
-    public void noDuplicateEntityPathsAcrossReturnedDependencies()
-    {
-        // Verifies that entity paths are unique across all returned dependency projects.
-        List<ProjectVersionEntities> deps = entitiesService.getDependenciesEntities(
-                Collections.singletonList(new ProjectVersion("examples.metadata", "test", "2.3.1")),
-                true, true);
-
-        List<String> allPaths = deps.stream()
-                .flatMap(pve -> pve.getEntities().stream())
-                .map(Entity::getPath)
-                .collect(Collectors.toList());
-
-        Set<String> uniquePaths = new HashSet<>(allPaths);
-        Assertions.assertEquals(allPaths.size(), uniquePaths.size(),
-                "Entity paths must be unique across all returned dependency projects");
-    }
 
     @Test
     public void legacyGavOverloadAlsoUsesMavenResolution()
@@ -304,12 +263,12 @@ public class TestEntitiesService extends TestBaseServices
         EntitiesServiceImpl<StoredEntity> service = new EntitiesServiceImpl<StoredEntity>(entities, projects);
 
         when(projects.resolveAliasesAndCheckVersionExists("examples.metadata", "test", "2.3.1")).thenReturn("2.3.1");
-        when(projects.getDependenciesMaven(anyList(), anyMap(), eq(true))).thenReturn(new HashSet<>());
+        when(projects.getDependenciesMaven(anyList(), anyMap(), eq(true), anyBoolean())).thenReturn(new HashSet<>());
         when(entities.getAllEntities(anyString(), anyString(), anyString())).thenReturn(Collections.emptyList());
 
         service.getDependenciesEntities("examples.metadata", "test", "2.3.1", true, false);
 
-        verify(projects).getDependenciesMaven(anyList(), anyMap(), eq(true));
+        verify(projects).getDependenciesMaven(anyList(), anyMap(), eq(true), anyBoolean());
         verify(projects, never()).getDependencies(anyList(), anyMap(), anyBoolean());
     }
 

--- a/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
+++ b/legend-depot-entities-services/src/test/java/org/finos/legend/depot/services/entities/TestEntitiesService.java
@@ -28,11 +28,14 @@ import org.finos.legend.depot.services.api.entities.EntityClassifierService;
 import org.finos.legend.depot.services.api.entities.ManageEntitiesService;
 import org.finos.legend.depot.services.api.metrics.query.QueryMetricsRegistry;
 import org.finos.legend.depot.services.api.notifications.queue.Queue;
+import org.finos.legend.depot.services.api.projects.ProjectsService;
 import org.finos.legend.depot.services.api.projects.ManageProjectsService;
 import org.finos.legend.depot.services.api.projects.configuration.ProjectsConfiguration;
 import org.finos.legend.depot.services.projects.ManageProjectsServiceImpl;
+import org.finos.legend.depot.store.api.entities.Entities;
 import org.finos.legend.depot.store.api.entities.UpdateEntities;
 import org.finos.legend.depot.store.model.entities.EntityDefinition;
+import org.finos.legend.depot.store.model.entities.StoredEntity;
 import org.finos.legend.depot.store.model.entities.StoredEntityData;
 import org.finos.legend.depot.store.model.entities.StoredEntityStringData;
 import org.finos.legend.depot.store.model.projects.StoreProjectData;
@@ -53,6 +56,10 @@ import java.util.function.Predicate;
 
 import static org.finos.legend.depot.domain.version.VersionValidator.BRANCH_SNAPSHOT;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestEntitiesService extends TestBaseServices
 {
@@ -195,6 +202,26 @@ public class TestEntitiesService extends TestBaseServices
         Assertions.assertEquals(3, dependencyList3.size());
         Assertions.assertEquals(1, dependencyList3.stream().filter(projectToArtifactFilter("examples.metadata", "test-dependencies")).findFirst().get().getEntities().size());
         Assertions.assertEquals(18, dependencyList3.stream().filter(projectToArtifactFilter("example.services.test", "test")).findFirst().get().getEntities().size());
+    }
+
+    @Test
+    public void legacyDependenciesLookupUsesMavenResolution()
+    {
+        Entities entities = mock(Entities.class);
+        ProjectsService projects = mock(ProjectsService.class);
+        EntitiesServiceImpl<StoredEntity> service = new EntitiesServiceImpl<StoredEntity>(entities, projects);
+
+        ProjectVersion projectVersion = new ProjectVersion("examples.metadata", "test", "2.3.1");
+        when(projects.resolveAliasesAndCheckVersionExists("examples.metadata", "test", "2.3.1")).thenReturn("2.3.1");
+        when(projects.getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true))).thenReturn(Collections.emptySet());
+        when(entities.getAllEntities("examples.metadata", "test", "2.3.1")).thenReturn(Collections.emptyList());
+
+        List<ProjectVersionEntities> dependencyList = service.getDependenciesEntities(Collections.singletonList(projectVersion), true, true);
+
+        Assertions.assertEquals(1, dependencyList.size());
+        Assertions.assertTrue(dependencyList.get(0).getEntities().isEmpty());
+        verify(projects).getDependenciesMaven(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), eq(true));
+        verify(projects, never()).getDependencies(org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.anyMap(), org.mockito.ArgumentMatchers.anyBoolean());
     }
 
     @Test


### PR DESCRIPTION

* Refactors EntitiesServiceImpl and related overloads so dependency-entity resolution for a list of root projects goes through the Maven-aware resolver instead of the legacy path, ensuring transitive version conflicts are deduplicated to a single version per GA. 

* Also fixes a related bug in ProjectsServiceImpl.getDependenciesMaven where transitive=false combined with includeOrigin=true incorrectly dropped the origin projects from the returned closure.