### PR TITLE
Migrate to Maven CI-friendly versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, '[maven-release-plugin]')"
+    if: "!startsWith(github.event.head_commit.message, 'Bump version to')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-# This action deletes the last two commits made on the master branch and the latest tag
-# This should only be run if a release failed and the remote staging repo has been dropped:
-# [ERROR]  * Dropping failed staging repository with ID "orgfinoslegend-..." ...
+# This action deletes the latest tag after a failed release.
+# With CI-friendly versions, there are no release commits to clean up — only the tag.
 name: Clean repo after failed release
 
 on: [workflow_dispatch]
@@ -40,5 +39,3 @@ jobs:
         run: |
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           git push --delete origin $LATEST_TAG
-          git reset --hard HEAD~2
-          git push --force

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -41,6 +41,21 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
+      - name: Check release version is unused
+        env:
+          RELEASE_VERSION: ${{ github.event.client_payload.releaseVersion }}
+          TAG: ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
+        run: |
+          set -euo pipefail
+          if ! [[ "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::releaseVersion must be MAJOR.MINOR.PATCH; got '${RELEASE_VERSION}'."
+            exit 1
+          fi
+          if git ls-remote --exit-code origin "refs/tags/${TAG}" > /dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists; ${RELEASE_VERSION} has been released."
+            exit 1
+          fi
+
       - name: Set up Maven Central
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -75,22 +75,34 @@ jobs:
             git push origin master
           fi
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.client_payload.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
       - name: Collect Workflow Telemetry
         uses: runforesight/workflow-telemetry-action@v1
         with:
           theme: dark
 
-      - name: Prepare release
-        run: mvn -B -DpreparationGoals=clean release:prepare -DreleaseVersion=${{ github.event.client_payload.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
+      - name: Build and deploy release
+        env:
+          RELEASE_VERSION: ${{ github.event.client_payload.releaseVersion }}
+        run: mvn -B -e -Drevision="${RELEASE_VERSION}" deploy -P release,docker
 
-      - name: Perform release
-        run: mvn -B release:perform -P release,docker
+      - name: Create and push git tag
+        env:
+          TAG: ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
+        run: |
+          set -euo pipefail
+          git tag "${TAG}"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Compute and set next SNAPSHOT
+        env:
+          RELEASE_VERSION: ${{ github.event.client_payload.releaseVersion }}
+        run: |
+          set -euo pipefail
+          IFS=. read -r major minor patch <<< "${RELEASE_VERSION}"
+          nextSnapshot="${major}.${minor}.$((patch + 1))-SNAPSHOT"
+          git fetch origin "${GITHUB_REF_NAME}"
+          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin "${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,21 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
+      - name: Check release version is unused
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+          TAG: ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+        run: |
+          set -euo pipefail
+          if ! [[ "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::releaseVersion must be MAJOR.MINOR.PATCH; got '${RELEASE_VERSION}'."
+            exit 1
+          fi
+          if git ls-remote --exit-code origin "refs/tags/${TAG}" > /dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists; ${RELEASE_VERSION} has been released."
+            exit 1
+          fi
+
       - name: Set up Maven Central
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,22 +55,34 @@ jobs:
           gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
           gpg-passphrase: CI_GPG_PASSPHRASE
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.inputs.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
       - name: Collect Workflow Telemetry
         uses: runforesight/workflow-telemetry-action@v1
         with:
           theme: dark
 
-      - name: Prepare release
-        run: mvn -B -DpreparationGoals=clean release:prepare -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
+      - name: Build and deploy release
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+        run: mvn -B -e -Drevision="${RELEASE_VERSION}" deploy -P release,docker
 
-      - name: Perform release
-        run: mvn -B release:perform -P release,docker
+      - name: Create and push git tag
+        env:
+          TAG: ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+        run: |
+          set -euo pipefail
+          git tag "${TAG}"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Compute and set next SNAPSHOT
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+        run: |
+          set -euo pipefail
+          IFS=. read -r major minor patch <<< "${RELEASE_VERSION}"
+          nextSnapshot="${major}.${minor}.$((patch + 1))-SNAPSHOT"
+          git fetch origin "${GITHUB_REF_NAME}"
+          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin "${GITHUB_REF_NAME}"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 **/lib
 **/surefire-reports-aggregate
 **/dependency-reduced-pom.xml
+**/.flattened-pom.xml
 **/jsconfig.json
 /temp/
 .settings

--- a/legend-depot-artifacts-api/pom.xml
+++ b/legend-depot-artifacts-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-artifacts-repository-api/pom.xml
+++ b/legend-depot-artifacts-repository-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-artifacts-repository-maven-impl/pom.xml
+++ b/legend-depot-artifacts-repository-maven-impl/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-artifacts-services/pom.xml
+++ b/legend-depot-artifacts-services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-artifacts-store-mongo/pom.xml
+++ b/legend-depot-artifacts-store-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-authorisation/pom.xml
+++ b/legend-depot-core-authorisation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-data-api/pom.xml
+++ b/legend-depot-core-data-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-data-services/pom.xml
+++ b/legend-depot-core-data-services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-data-store-mongo/pom.xml
+++ b/legend-depot-core-data-store-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-schedules-api/pom.xml
+++ b/legend-depot-core-schedules-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-schedules-store-mongo/pom.xml
+++ b/legend-depot-core-schedules-store-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-schedules/pom.xml
+++ b/legend-depot-core-schedules/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-store-api/pom.xml
+++ b/legend-depot-core-store-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-core-tracing/pom.xml
+++ b/legend-depot-core-tracing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-entities-api/pom.xml
+++ b/legend-depot-entities-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-entities-services/pom.xml
+++ b/legend-depot-entities-services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-entities-store-mongo/pom.xml
+++ b/legend-depot-entities-store-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-generations-api/pom.xml
+++ b/legend-depot-generations-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-generations-services/pom.xml
+++ b/legend-depot-generations-services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-generations-store-mongo/pom.xml
+++ b/legend-depot-generations-store-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-metrics-query-api/pom.xml
+++ b/legend-depot-metrics-query-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-metrics-query-services/pom.xml
+++ b/legend-depot-metrics-query-services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-metrics-query-store-mongo/pom.xml
+++ b/legend-depot-metrics-query-store-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-model/pom.xml
+++ b/legend-depot-model/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-notifications-api/pom.xml
+++ b/legend-depot-notifications-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-notifications-queue-mongo/pom.xml
+++ b/legend-depot-notifications-queue-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-notifications-services/pom.xml
+++ b/legend-depot-notifications-services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-notifications-store-mongo/pom.xml
+++ b/legend-depot-notifications-store-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-pure-model-context/pom.xml
+++ b/legend-depot-pure-model-context/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-server/pom.xml
+++ b/legend-depot-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-servers-common/pom.xml
+++ b/legend-depot-servers-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>legend-depot</artifactId>
         <groupId>org.finos.legend.depot</groupId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-store-mongo/pom.xml
+++ b/legend-depot-store-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-store-server/pom.xml
+++ b/legend-depot-store-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-depot-test-reports/pom.xml
+++ b/legend-depot-test-reports/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.depot</groupId>
         <artifactId>legend-depot</artifactId>
-        <version>2.96.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>Legend Depot</name>
     <groupId>org.finos.legend.depot</groupId>
     <artifactId>legend-depot</artifactId>
-    <version>2.96.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -85,6 +85,9 @@
     </modules>
 
     <properties>
+        <!-- CI-Friendly Version -->
+        <revision>2.96.1-SNAPSHOT</revision>
+
         <sonar.projectKey>finos_legend-depot</sonar.projectKey>
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
         <sonar.organization>finos</sonar.organization>
@@ -418,6 +421,31 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>


### PR DESCRIPTION
Follow-up to finos/legend-shared#249: the same migration to Maven CI-friendly versions.

## POMs

- Every pom's own version and every `<parent><version>` is now `${revision}`; the version is defined once, in the root pom's `<revision>` property.
- `flatten-maven-plugin` 1.6.0 (`resolveCiFriendliesOnly`, bound to `process-resources` and `clean`) writes the resolved version into installed and deployed poms. `.flattened-pom.xml` is git-ignored.

## Release workflows

`maven-release-plugin` is gone. A release now:

1. validates the version format and checks the tag does not already exist,
2. builds, tests and publishes the dispatched commit with `-Drevision=<version>`,
3. pushes the tag `legend-depot-<version>` onto that commit,
4. commits `Bump version to <next>-SNAPSHOT` on the branch tip (fetched first, so a commit landing during the release does not make the push fail) and pushes it to the branch the workflow ran on.

No release commits, no rebuild from the tag, no force-push cleanup: `clean-after-failed-release.yml` now only deletes the tag. `build.yml` skips CI for the bump commit (message starting `Bump version to`) instead of for `[maven-release-plugin]` commits. `legend-stack-release.yml` is migrated the same way; its "Legend Stack Versions upgrade" commit is unchanged and is the commit that gets built and tagged.

In a single-job `mvn deploy` workflow the tag is pushed after the deploy, because the tests run inside `deploy`. If the deploy succeeds and the tag push fails, the version is published but untagged: tag by hand rather than running the cleanup workflow.
## Verification

- `mvn -Drevision=9.9.9-TEST -DskipTests install` on the whole reactor: 35/35 modules. Every installed pom carries the literal version; none contains `${revision}`.
- Default build still resolves to the current SNAPSHOT.
- Release paths (deploy, tag push, bump) were reviewed by reading, not executed.
