### PR TITLE
update central-publishing-maven-plugin to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,6 +449,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.11.0</version>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>


### PR DESCRIPTION
new version adds a warning field to the DeploymentApiResponse which caused `com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "warnings" (class org.sonatype.central.publisher.client.model.DeploymentApiResponse), not marked as ignorable (6 known properties: "deploymentId", "purls", "cherryBomUrl", "errors", "deploymentState", "deploymentName"]) ` when creating a release using an older version